### PR TITLE
feat: manage Caddyfile with a docker config

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -19,6 +19,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Trigger on main to clear the lock
+  push:
+    branches: [ "main" ]
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 

--- a/ansible/roles/docker-swarm-app-caddy/assets/Caddyfile
+++ b/ansible/roles/docker-swarm-app-caddy/assets/Caddyfile
@@ -9,7 +9,7 @@
 	dynamic_dns {
 		provider digitalocean {env.DIGITALOCEAN_API_TOKEN}
 		domains {
-			{{domain}} @ www
+			{$DOMAIN} @ www
 		}
 		dynamic_domains
 	}
@@ -20,7 +20,7 @@
 		authentication portal myportal {
 			crypto default token lifetime 3600
 			crypto key sign-verify {env.JWT_SHARED_KEY}
-			cookie domain {{domain}}
+			cookie domain {$DOMAIN}
 			enable identity provider github
 			ui {
 				links {
@@ -36,7 +36,7 @@
 		}
 
 		authorization policy admins_policy {
-			set auth url https://auth.{{domain}}/oauth2/github
+			set auth url https://auth.{$DOMAIN}/oauth2/github
 			crypto key verify {env.JWT_SHARED_KEY}
 			allow roles authp/admin authp/user
 			validate bearer header
@@ -58,15 +58,15 @@
 }
 
 # Snippet enable automatic DNS configuration
-(external-dns) {
+(dns-challenge) {
 	tls {
 		dns digitalocean {env.DIGITALOCEAN_API_TOKEN}
 	}
 }
 
 # Auth endpoint for caddy security
-auth.{{domain}} {
-	import external-dns
+auth.{$DOMAIN} {
+	import dns-challenge
 	authenticate with myportal
 }
 

--- a/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
+++ b/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
@@ -26,6 +26,7 @@ services:
       - caddy_jwt_shared_key
       - caddy_digitalocean_api_token
     environment:
+      DOMAIN: "{{ domain }}"
       GITHUB_CLIENT_ID_FILE: /run/secrets/caddy_github_client_id
       GITHUB_CLIENT_SECRET_FILE: /run/secrets/caddy_github_client_secret
       JWT_SHARED_KEY_FILE: /run/secrets/caddy_jwt_shared_key
@@ -57,6 +58,10 @@ services:
 volumes:
   caddy_data:
   caddy_config:
+
+config:
+  global_caddyfile:
+    external: true
 
 networks:
   caddy:

--- a/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
+++ b/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
@@ -61,7 +61,7 @@ volumes:
   caddy_data:
   caddy_config:
 
-config:
+configs:
   caddy_global_caddyfile:
     external: true
 

--- a/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
+++ b/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
@@ -17,9 +17,11 @@ services:
       - caddy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - "{{ caddy_dir }}/Caddyfile:/etc/caddy/Caddyfile"
       - caddy_data:/data
       - caddy_config:/config
+    configs:
+      - source: global_caddyfile
+        target: "/etc/caddy/Caddyfile"
     secrets:
       - caddy_github_client_id
       - caddy_github_client_secret

--- a/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
+++ b/ansible/roles/docker-swarm-app-caddy/assets/caddy-stack.yml
@@ -20,7 +20,7 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     configs:
-      - source: global_caddyfile
+      - source: caddy_global_caddyfile
         target: "/etc/caddy/Caddyfile"
     secrets:
       - caddy_github_client_id
@@ -62,7 +62,7 @@ volumes:
   caddy_config:
 
 config:
-  global_caddyfile:
+  caddy_global_caddyfile:
     external: true
 
 networks:

--- a/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
+++ b/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
@@ -36,7 +36,7 @@
   vars:
     docker_compose_path: "{{ caddy_dir }}/caddy-stack.yml"
     configs:
-      - {name: 'global_caddyfile', file_path: "{{ assets_path }}/Caddyfile"}
+      - {name: 'global_caddyfile', file_path: "{{ caddy_dir }}/Caddyfile"}
 
 - name: Manager Caddy Secrets
   include_role:

--- a/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
+++ b/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
@@ -36,7 +36,7 @@
   vars:
     docker_compose_path: "{{ caddy_dir }}/caddy-stack.yml"
     configs:
-      - {name: 'global_caddyfile', value: "{{ lookup('ansible.builtin.file', assets_path + '/Caddyfile') }}"}
+      - {name: 'global_caddyfile', file_path: "{{ assets_path }}/Caddyfile"}
 
 - name: Manager Caddy Secrets
   include_role:

--- a/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
+++ b/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
@@ -36,7 +36,7 @@
   vars:
     docker_compose_path: "{{ caddy_dir }}/caddy-stack.yml"
     configs:
-      - {name: 'global_caddyfile', file_path: "{{ caddy_dir }}/Caddyfile"}
+      - {name: 'caddy_global_caddyfile', file_path: "{{ caddy_dir }}/Caddyfile"}
 
 - name: Manager Caddy Secrets
   include_role:

--- a/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
+++ b/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
@@ -32,7 +32,7 @@
   vars:
     docker_compose_path: "{{ caddy_dir }}/caddy-stack.yml"
     configs:
-      - {name: 'caddyfile', value: "{{ lookup('ansible.builtin.file', caddy_dir + '/Caddyfile') }}"}
+      - {name: 'caddyfile', value: "{{ lookup('ansible.builtin.file', role_path + '/Caddyfile') }}"}
 
 - name: Manager Caddy Secrets
   include_role:

--- a/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
+++ b/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
@@ -13,15 +13,19 @@
     state: directory
     mode: '0644'
 
+- name: Define asssets folder
+  set_fact:
+    assets_path: "{{ role_path }}/assets"
+
 - name: Copy Compose file to remote server
   template:
     src: "{{ item }}"
     dest: "{{ caddy_dir }}"
     mode: '0644'
   with_fileglob:
-    - "{{ role_path }}/assets/*-stack.yml"
-    - "{{ role_path }}/assets/Caddyfile"
-    - "{{ role_path }}/assets/Dockerfile"
+    - "{{ assets_path }}/*-stack.yml"
+    - "{{ assets_path }}/Caddyfile"
+    - "{{ assets_path }}/Dockerfile"
 
 ###
 # Create Caddy Pre-requisits
@@ -32,7 +36,7 @@
   vars:
     docker_compose_path: "{{ caddy_dir }}/caddy-stack.yml"
     configs:
-      - {name: 'caddyfile', value: "{{ lookup('ansible.builtin.file', role_path + '/Caddyfile') }}"}
+      - {name: 'global_caddyfile', value: "{{ lookup('ansible.builtin.file', assets_path + '/Caddyfile') }}"}
 
 - name: Manager Caddy Secrets
   include_role:

--- a/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
+++ b/ansible/roles/docker-swarm-app-caddy/tasks/main.yaml
@@ -26,6 +26,14 @@
 ###
 # Create Caddy Pre-requisits
 ###
+- name: Manager Caddy Configs
+  include_role:
+    name: utils-rotate-docker-configs
+  vars:
+    docker_compose_path: "{{ caddy_dir }}/caddy-stack.yml"
+    configs:
+      - {name: 'caddyfile', value: "{{ lookup('ansible.builtin.file', caddy_dir + '/Caddyfile') }}"}
+
 - name: Manager Caddy Secrets
   include_role:
     name: utils-rotate-docker-secrets

--- a/ansible/roles/utils-rotate-docker-configs/defaults/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/defaults/main.yaml
@@ -1,3 +1,1 @@
-checksum_directory: /var/data/ansible
-checksum_file: configs.ini
 docker_compose_path: "{{ undef(hint='You must specify docker-compose file to update') }}"

--- a/ansible/roles/utils-rotate-docker-configs/defaults/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/defaults/main.yaml
@@ -1,0 +1,3 @@
+checksum_directory: /var/data/ansible
+checksum_file: configs.ini
+docker_compose_path: "{{ undef(hint='You must specify docker-compose file to update') }}"

--- a/ansible/roles/utils-rotate-docker-configs/handlers/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/handlers/main.yaml
@@ -1,0 +1,18 @@
+- name: List all Docker configs managed by this role
+  command: docker config ls --filter label=managed_by=rotate_docker_configs --format "{{ '{{ .Name }}' }}"
+  register: existing_configs
+  changed_when: false
+
+- name: Identify configs to keep
+  set_fact:
+    configs_to_keep: "{{ configs_to_keep | default([]) + [item.name + '_' + config_checksums[item.name]] }}"
+  loop: "{{ configs }}"
+
+- name: Remove dangling configs
+  docker_config:
+    name: "{{ item }}"
+    state: absent
+  when: item not in configs_to_keep
+  loop: "{{ existing_configs.stdout_lines }}"
+  ignore_errors: true
+  register: ignore_errors_register

--- a/ansible/roles/utils-rotate-docker-configs/meta/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -32,7 +32,7 @@
           'ansible.builtin.ini',
           'checksum',
           section=item.name,
-          file=checksum_directory + '/{{ checksum_file }}'
+          file=checksum_directory + '/' + checksum_file
           )
         })
       }}"

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -1,9 +1,3 @@
-- name: Ensure checksum directory exists
-  file:
-    path: "{{ checksum_directory }}"
-    mode: '0644'
-    state: directory
-
 - name: Gather file stats and checksums
   stat:
     path: "{{ item.file_path }}"
@@ -18,27 +12,6 @@
   loop_control:
     index_var: idx
 
-- name: Check if previous checksums file exists
-  stat:
-    path: "{{ checksum_directory }}/{{ checksum_file }}"
-  register: previous_checksums_file
-
-- name: Load previous checksums if file exists
-  set_fact:
-    previous_checksums: "{{ previous_checksums
-      | default({})
-      | combine({
-          item.name: lookup(
-          'ansible.builtin.ini',
-          'checksum',
-          section=item.name,
-          file=checksum_directory + '/' + checksum_file
-          )
-        })
-      }}"
-  loop: "{{ configs }}"
-  when: previous_checksums_file.stat.exists
-
 - name: Create new configs if value has changed
   docker_config:
     name: "{{ item.name }}_{{ config_checksums[item.name] }}"
@@ -47,16 +20,6 @@
     labels:
       managed_by: "rotate_docker_configs"
       name: "{{ item.name }}"
-  when: (previous_checksums[item.name] is not defined) or (previous_checksums[item.name] != config_checksums[item.name])
-  loop: "{{ configs }}"
-
-- name: Update checksums file
-  ini_file:
-    path: "{{ checksum_directory }}/{{ checksum_file }}"
-    section: "{{ item.name }}"
-    option: checksum
-    value: "{{ config_checksums[item.name] }}"
-    mode: '0644'
   loop: "{{ configs }}"
 
 - name: Replace config names in Docker Compose file

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -1,0 +1,62 @@
+- name: Ensure checksum directory exists
+  file:
+    path: "{{ checksum_directory }}"
+    mode: '0644'
+    state: directory
+
+- name: Calculate checksums for configs
+  set_fact:
+    config_checksums: "{{ config_checksums
+      | default({})
+      | combine({item.name: lookup('pipe', 'echo ' + item.value + '
+      | md5sum
+      | cut -d\" \" -f1')}) }}"
+  loop: "{{ configs }}"
+
+- name: Check if previous checksums file exists
+  stat:
+    path: "{{ checksum_directory }}/{{ checksum_file }}"
+  register: previous_checksums_file
+
+- name: Load previous checksums if file exists
+  set_fact:
+    previous_checksums: "{{ previous_checksums
+      | default({})
+      | combine({
+          item.name: lookup(
+          'ansible.builtin.ini',
+          'checksum',
+          section=item.name,
+          file=checksum_directory + '{{ checksum_file }}'
+          )
+        })
+      }}"
+  loop: "{{ configs }}"
+  when: previous_checksums_file.stat.exists
+
+- name: Create new configs if value has changed
+  docker_config:
+    name: "{{ item.name }}_{{ config_checksums[item.name] }}"
+    data: "{{ item.value }}"
+    state: present
+    labels:
+      managed_by: "rotate_docker_configs"
+      name: "{{ item.name }}"
+  when: (previous_checksums[item.name] is not defined) or (previous_checksums[item.name] != config_checksums[item.name])
+  loop: "{{ configs }}"
+
+- name: Update checksums file
+  ini_file:
+    path: "{{ checksum_file }}"
+    section: "{{ item.name }}"
+    option: checksum
+    value: "{{ config_checksums[item.name] }}"
+    mode: '0644'
+  loop: "{{ configs }}"
+
+- name: Replace config names in Docker Compose file
+  replace:
+    path: "{{ docker_compose_path }}"
+    regexp: "{{ item.name }}(_[a-f0-9]{32})?"
+    replace: "{{ item.name }}_{{ config_checksums[item.name] }}"
+  loop: "{{ configs }}"

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -7,12 +7,9 @@
 - name: Gather file stats and checksums
   stat:
     path: "{{ item.file_path }}"
+    checksum: md5
   loop: "{{ configs }}"
   register: file_stats
-
-- name: Print file stats
-  ansible.builtin.debug:
-    msg: "{{ file_stats }}"
 
 - name: Create dictionary of checksums
   set_fact:

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -12,8 +12,10 @@
 
 - name: Create dictionary of checksums
   set_fact:
-    config_checksums: "{{ config_checksums | default({}) | combine({ item.name: file_stats[item.name].stat.checksum }) }}"
+    config_checksums: "{{ config_checksums | default({}) | combine({ item.name: file_stats.results[idx].stat.checksum }) }}"
   loop: "{{ configs }}"
+  loop_control:
+    index_var: idx
 
 - name: Check if previous checksums file exists
   stat:

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -42,7 +42,7 @@
 - name: Create new configs if value has changed
   docker_config:
     name: "{{ item.name }}_{{ config_checksums[item.name] }}"
-    data: "{{ lookup('file', item.file_path) }}"
+    data_src: "{{ item.file_path }}"
     state: present
     labels:
       managed_by: "rotate_docker_configs"

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -4,13 +4,15 @@
     mode: '0644'
     state: directory
 
-- name: Calculate checksums for configs
+- name: Gather file stats and checksums
+  stat:
+    path: "{{ item.file_path }}"
+  loop: "{{ configs }}"
+  register: file_stats
+
+- name: Create dictionary of checksums
   set_fact:
-    config_checksums: "{{ config_checksums
-      | default({})
-      | combine({item.name: lookup('pipe', 'echo ' + item.value + '
-      | md5sum
-      | cut -d\" \" -f1')}) }}"
+    config_checksums: "{{ config_checksums | default({}) | combine({ item.name: file_stats[item.name].stat.checksum }) }}"
   loop: "{{ configs }}"
 
 - name: Check if previous checksums file exists
@@ -37,7 +39,7 @@
 - name: Create new configs if value has changed
   docker_config:
     name: "{{ item.name }}_{{ config_checksums[item.name] }}"
-    data: "{{ item.value }}"
+    data: "{{ lookup('file', item.file_path) }}"
     state: present
     labels:
       managed_by: "rotate_docker_configs"

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -10,6 +10,10 @@
   loop: "{{ configs }}"
   register: file_stats
 
+- name: Print file stats
+  ansible.builtin.debug:
+    msg: "{{ file_stats }}"
+
 - name: Create dictionary of checksums
   set_fact:
     config_checksums: "{{ config_checksums | default({}) | combine({ item.name: file_stats.results[idx].stat.checksum }) }}"

--- a/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-configs/tasks/main.yaml
@@ -32,7 +32,7 @@
           'ansible.builtin.ini',
           'checksum',
           section=item.name,
-          file=checksum_directory + '{{ checksum_file }}'
+          file=checksum_directory + '/{{ checksum_file }}'
           )
         })
       }}"
@@ -52,7 +52,7 @@
 
 - name: Update checksums file
   ini_file:
-    path: "{{ checksum_file }}"
+    path: "{{ checksum_directory }}/{{ checksum_file }}"
     section: "{{ item.name }}"
     option: checksum
     value: "{{ config_checksums[item.name] }}"

--- a/ansible/roles/utils-rotate-docker-secrets/defaults/main.yaml
+++ b/ansible/roles/utils-rotate-docker-secrets/defaults/main.yaml
@@ -1,2 +1,3 @@
 checksum_directory: /var/data/ansible
+checksum_file: secret.ini
 docker_compose_path: "{{ undef(hint='You must specify docker-compose file to update') }}"

--- a/ansible/roles/utils-rotate-docker-secrets/defaults/main.yaml
+++ b/ansible/roles/utils-rotate-docker-secrets/defaults/main.yaml
@@ -1,3 +1,1 @@
-checksum_directory: /var/data/ansible
-checksum_file: secret.ini
 docker_compose_path: "{{ undef(hint='You must specify docker-compose file to update') }}"

--- a/ansible/roles/utils-rotate-docker-secrets/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-secrets/tasks/main.yaml
@@ -1,9 +1,3 @@
-- name: Ensure checksum directory exists
-  file:
-    path: "{{ checksum_directory }}"
-    mode: '0644'
-    state: directory
-
 - name: Calculate checksums for secrets
   set_fact:
     secret_checksums: "{{ secret_checksums
@@ -12,27 +6,6 @@
       | md5sum
       | cut -d\" \" -f1')}) }}"
   loop: "{{ secrets }}"
-
-- name: Check if previous checksums file exists
-  stat:
-    path: "{{ checksum_directory }}/secrets.ini"
-  register: previous_checksums_file
-
-- name: Load previous checksums if file exists
-  set_fact:
-    previous_checksums: "{{ previous_checksums
-      | default({})
-      | combine({
-          item.name: lookup(
-          'ansible.builtin.ini',
-          'checksum',
-          section=item.name,
-          file=checksum_directory + '/' + checksum_file
-          )
-        })
-      }}"
-  loop: "{{ secrets }}"
-  when: previous_checksums_file.stat.exists
 
 - name: Create new secrets if value has changed
   docker_secret:
@@ -43,15 +16,6 @@
       managed_by: "rotate_docker_secrets"
       name: "{{ item.name }}"
   when: (previous_checksums[item.name] is not defined) or (previous_checksums[item.name] != secret_checksums[item.name])
-  loop: "{{ secrets }}"
-
-- name: Update checksums file
-  ini_file:
-    path: "{{ checksum_directory }}/{{checksum_file}}"
-    section: "{{ item.name }}"
-    option: checksum
-    value: "{{ secret_checksums[item.name] }}"
-    mode: '0644'
   loop: "{{ secrets }}"
 
 - name: Replace secret names in Docker Compose file

--- a/ansible/roles/utils-rotate-docker-secrets/tasks/main.yaml
+++ b/ansible/roles/utils-rotate-docker-secrets/tasks/main.yaml
@@ -27,7 +27,7 @@
           'ansible.builtin.ini',
           'checksum',
           section=item.name,
-          file=checksum_directory + '/secrets.ini'
+          file=checksum_directory + '/' + checksum_file
           )
         })
       }}"
@@ -47,7 +47,7 @@
 
 - name: Update checksums file
   ini_file:
-    path: ./secrets.ini
+    path: "{{ checksum_directory }}/{{checksum_file}}"
     section: "{{ item.name }}"
     option: checksum
     value: "{{ secret_checksums[item.name] }}"


### PR DESCRIPTION
Managing configs via `docker configs` is a more sustainable approach. The missing piece until there was to update configs since they are immutable, but now that I have the recipe for rotating secrets, I can apply the same concept to configs.