### PR TITLE
docs: Enhance Caddy documentation

### DIFF
--- a/website/content/en/docs/a1.caddy.md
+++ b/website/content/en/docs/a1.caddy.md
@@ -2,3 +2,70 @@
 title: Caddy
 slug: caddy
 ---
+
+## Introduction to Caddy
+
+Caddy is a powerful, enterprise-ready, open source web server with automatic HTTPS. In this setup, Caddy serves as a crucial reverse proxy and authentication gateway for applications deployed within the Docker Swarm cluster. It simplifies exposing services to the internet, handles SSL/TLS certificate management, and enforces access control.
+
+## Deployment Process
+
+Caddy is deployed as a Docker Swarm service using the `docker_swarm_app_caddy` Ansible role. This role automates the entire setup process.
+
+Key actions performed by the Ansible role include:
+
+*   **Copying Essential Files:**
+    *   `Caddyfile`: The main configuration file for Caddy, defining how requests are handled, reverse proxy rules, and authentication policies.
+    *   `Dockerfile`: Used to build a custom Caddy image that includes necessary plugins.
+    *   `caddy-stack.yml`: A Docker Compose file that defines the Caddy service, its network, and dependencies.
+*   **Managing `Caddyfile` as a Docker Swarm Config:** The `Caddyfile` is managed as a Docker Swarm configuration object. This allows for dynamic updates to the Caddy configuration without restarting the service. The `utils_rotate_docker_configs` Ansible role is utilized for this purpose, ensuring versioned and controlled rollout of configuration changes.
+*   **Managing Sensitive Data as Docker Swarm Secrets:** Sensitive information required by Caddy and its plugins is securely managed as Docker Swarm secrets. This includes:
+    *   GitHub OAuth credentials (`CADDY_GITHUB_CLIENT_ID`, `CADDY_GITHUB_CLIENT_SECRET`) for the authentication portal.
+    *   DigitalOcean API token (`CADDY_DIGITALOCEAN_API_TOKEN`) for DNS challenges (if using DigitalOcean for DNS).
+    *   JWT signing key (`CADDY_JWT_SHARED_KEY`) for securing authentication tokens.
+    The `utils_rotate_docker_secrets` Ansible role handles the creation and rotation of these secrets.
+*   **Deploying the Caddy Stack:** The Caddy service itself is deployed as a Docker stack using the `docker_stack` Ansible module, based on the `caddy-stack.yml` file.
+
+### Custom Caddy Image
+
+A custom Caddy image is built and used to ensure all necessary functionalities are available. The image is `ghcr.io/xnok/infra-bootstrap-tools-caddy:main` and includes the following key plugins:
+
+*   **`github.com/lucaslorentz/caddy-docker-proxy/v2`:** This plugin enables Caddy to dynamically discover and configure reverse proxying for Docker Swarm services based on labels applied to those services.
+*   **`github.com/greenpau/caddy-security`:** This plugin provides robust authentication and authorization capabilities, including support for OAuth/OIDC providers like GitHub, JWT, and more.
+*   **`github.com/mholt/caddy-dynamicdns`:** This plugin allows Caddy to automatically update DNS records, which is useful for dynamic IP environments or for managing DNS records for services it exposes.
+
+## Securing Applications with Caddy and Docker Labels
+
+The core concept for exposing and securing applications with Caddy in this environment revolves around Docker Swarm service labels. The `caddy-docker-proxy` plugin continuously monitors Docker Swarm for services that have specific labels, and automatically configures Caddy to act as a reverse proxy for them.
+
+To expose a service through Caddy, you define labels on your *other* Docker Swarm services (not on Caddy itself). These labels instruct Caddy on how to route traffic to your application.
+
+Here are examples of common labels:
+
+*   **`caddy.enable=true`**: This is the most basic label. Setting it to `true` tells Caddy to expose this service.
+    *   If your Caddy instance is configured to watch multiple Docker networks or you have multiple Caddy services with different configurations, you might need to namespace the label, e.g., `caddy_myservicenet.enable=true`.
+*   **`caddy.hostname=subdomain.your_domain.com`**: This label specifies the public hostname (domain or subdomain) that will be used to access your service. Caddy will automatically provision an SSL certificate for this hostname.
+*   **`caddy.targetport=container_port_number`**: This crucial label tells Caddy which port your application container is listening on internally. For example, if your Node.js app listens on port 3000, you would set `caddy.targetport=3000`.
+*   **`caddy.proxy.try_duration=10s`**: You can pass more specific Caddy directives using labels. This example sets the `try_duration` for the reverse proxy, useful for services that might take a moment to start up. Many Caddyfile directives can be translated into labels by prefixing them with `caddy.`.
+
+**Automatic HTTPS:** A significant advantage of this setup is that any service exposed through Caddy using these labels will automatically benefit from HTTPS. Caddy handles the entire lifecycle of SSL/TLS certificates, including issuance and renewal, typically using Let's Encrypt.
+
+## Authentication and Authorization
+
+An authentication portal is available, typically at `auth.YOUR_DOMAIN` (replace `YOUR_DOMAIN` with your actual domain). This portal is implemented using the `caddy-security` plugin.
+
+*   **Identity Provider:** GitHub OAuth is configured as the primary identity provider. Users will be redirected to GitHub to log in and authorize the application.
+*   **Authorization Policy:** Access to applications secured by Caddy is typically granted based on membership to a specific GitHub organization. This policy is defined within the `Caddyfile` and enforced by the `caddy-security` plugin. Only authenticated users who are members of the designated GitHub organization will be allowed to access the protected services.
+
+## Requirements
+
+For the `docker_swarm_app_caddy` Ansible role to deploy and configure Caddy successfully, the following prerequisites must be met:
+
+*   **DigitalOcean API Token:** A DigitalOcean API token with DNS read and write permissions for your domain. This is required if Caddy is managing DNS records via the `caddy-dynamicdns` plugin with the DigitalOcean provider.
+*   **Configured GitHub OAuth Application:**
+    *   **Homepage URL:** `https://auth.YOUR_DOMAIN` (e.g., `https://auth.example.com`)
+    *   **Authorization callback URL:** `https://auth.YOUR_DOMAIN/oauth2/github/callback` (e.g., `https://auth.example.com/oauth2/github/callback`)
+*   **Environment Variables on Ansible Control Node:** The following environment variables must be set on the machine where you run Ansible:
+    *   `CADDY_GITHUB_CLIENT_ID`: The Client ID of your GitHub OAuth application.
+    *   `CADDY_GITHUB_CLIENT_SECRET`: The Client Secret of your GitHub OAuth application.
+    *   `CADDY_JWT_SHARED_KEY`: A strong, randomly generated secret key used for signing JWTs by `caddy-security`. You can generate one with `openssl rand -hex 32`.
+    *   `CADDY_DIGITALOCEAN_API_TOKEN`: Your DigitalOcean API token (if applicable).


### PR DESCRIPTION
Detailed Caddy server documentation, covering:
- Introduction to Caddy and its role as a reverse proxy/auth gateway.
- Deployment process using the `docker_swarm_app_caddy` Ansible role, including management of configurations and secrets.
- Explanation of the custom Caddy Docker image and its included plugins (caddy-docker-proxy, caddy-security, caddy-dynamicdns).
- How to secure applications by leveraging Docker service labels for automatic reverse proxy configuration and HTTPS.
- Overview of the authentication portal using GitHub OAuth and organization-based authorization.
- Prerequisites for the Ansible role (API tokens, GitHub OAuth app, environment variables).

This addresses the issue of improving documentation for Caddy, focusing on its deployment and usage within a Docker Swarm environment, particularly how it uses the caddy-docker-proxy plugin and labels for service discovery and security.