### PR TITLE
docs: Add Tools Showcase section and update setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,32 @@ Features:
 * Caddy
 * Portainer
 
+## Development Environment Setup
+
+This project provides a script to help you set up your local development environment. Additionally, a Gitpod configuration is available for a cloud-based, ready-to-use environment.
+
+### Local Setup Script
+
+The `./bin/bash/setup.sh` script can install the following tools:
+
+*   **pre-commit**: For running linters and formatters automatically before committing code.
+*   **Ansible**: For infrastructure automation.
+*   **1Password CLI**: For managing secrets.
+*   **Boilerplate**: For generating boilerplate code.
+*   **Hugo**: For building and serving the documentation website.
+
+To use the script, run it with the names of the tools you want to install. For example, to install pre-commit and Ansible:
+
+```bash
+./bin/bash/setup.sh pre-commit ansible
+```
+
+### Gitpod
+
+Alternatively, you can use Gitpod to get a pre-configured development environment in your browser. Click the button below to get started:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## 🚀 Quick Start
 
 Got your [prerequisites](./website/content/en/docs/gs1.getting_started.md#prerequisites) and [secrets configured](./website/content/en/docs/gs1.getting_started.md#configuration-secrets-management)?
@@ -114,6 +140,15 @@ use dpk for packer in docker
 use dtf for terraform in docker
 use dbash for bash in docker
 ```
+
+## Tools Showcase
+
+This project leverages several tools to streamline development and improve code quality. Here's a brief overview of some of them:
+
+*   **Pre-commit**: We use pre-commit hooks to automate linting, formatting, and other checks before code is committed. This helps maintain code consistency and catch errors early. Configuration can be found in `.pre-commit-config.yaml`.
+*   **1Password CLI**: For securely managing sensitive information like API keys and passwords, the 1Password CLI can be integrated into your workflow. The setup script provides an option to install it.
+*   **Boilerplate**: [Gruntwork Boilerplate](https://github.com/gruntwork-io/boilerplate) is used to generate répétitive code structures, ensuring consistency and saving time. You can find boilerplate templates in the `.boilerplates` directory.
+*   **Hugo**: The project documentation website (what you're likely reading if you're on the website!) is built using [Hugo](https://gohugo.io/), a fast and flexible static site generator. The website content is in the `website/` directory.
 
 ## Scale Up
 

--- a/website/content/en/docs/gs1.getting_started.md
+++ b/website/content/en/docs/gs1.getting_started.md
@@ -18,6 +18,22 @@ Before you begin, ensure you have the following tools and accounts:
     *   **Recommended (That's what I use):** 1Password & 1Password CLI (`op`). [Set up 1Password CLI](https://developer.1password.com/docs/cli/get-started/). The examples in this guide use 1Password.
     *   **Alternatives:** Ansible Vault, environment variables, direct input in variable files (not recommended for sensitive data in Git), or other Ansible lookup plugins.
 
+##### Development Environment Setup
+
+While not strictly required for deploying the infrastructure, if you plan to contribute to this project or customize it extensively, setting up a consistent development environment is recommended.
+
+*   **Using the Setup Script**: This project includes a helper script to install common tools used for development, such as `pre-commit` for linting, `ansible`, `hugo` for the documentation site, etc. You can find this script at `./bin/bash/setup.sh`. To install specific tools, run:
+    ```bash
+    ./bin/bash/setup.sh <tool_name_1> <tool_name_2>
+    ```
+    For example, to install `pre-commit` and `hugo`:
+    ```bash
+    ./bin/bash/setup.sh pre-commit hugo
+    ```
+    Run the script without arguments or with an invalid tool name to see the list of available tools.
+
+*   **Using Gitpod**: For a cloud-based, pre-configured development environment, you can use Gitpod. This is the quickest way to get started without installing anything on your local machine. Look for the "Open in Gitpod" button in the main `README.md` of the project.
+
 #### Configuration - Secrets Management
 
 Sensitive information, such as API keys and tokens, is required to provision and configure the infrastructure. This project requires sensitive information like API keys. The author prefers using 1Password for managing these, and the examples show this method. However, you can adapt this to your preferred secret management tool (e.g., Ansible Vault, environment variables, or other lookup plugins).

--- a/website/content/en/docs/tools/1password-cli.md
+++ b/website/content/en/docs/tools/1password-cli.md
@@ -1,0 +1,17 @@
+---
+title: "1Password CLI"
+weight: 2 # Second item in Tools Showcase
+---
+
+## 1Password CLI
+
+The 1Password CLI (`op`) provides a command-line interface to interact with your 1Password vaults. It allows you to securely fetch secrets, credentials, and other sensitive information stored in 1Password, making it useful for scripting and automation.
+
+### Usage in this Project
+
+This project recommends using 1Password CLI for managing sensitive data like API tokens, SSH keys, and other credentials needed by Ansible and Terraform.
+
+*   **Secret Retrieval**: The Ansible playbooks are configured to use the `op` lookup plugin to fetch secrets directly from 1Password vaults during runtime. This avoids hardcoding sensitive information in your configuration files. You can see examples in `ansible/playbooks/host_vars/localhost.yml`.
+*   **Setup**: The `./bin/bash/setup.sh 1password-cli` script can help you install the 1Password CLI.
+
+You will need to have a 1Password account and the CLI configured to use it with this project if you choose this method for secret management.

--- a/website/content/en/docs/tools/boilerplate.md
+++ b/website/content/en/docs/tools/boilerplate.md
@@ -1,0 +1,17 @@
+---
+title: "Boilerplate (Gruntwork)"
+weight: 3 # Third item in Tools Showcase
+---
+
+## Boilerplate (Gruntwork)
+
+[Gruntwork Boilerplate](https://github.com/gruntwork-io/boilerplate) is a tool that helps you create and manage reusable templates for your code and configuration. It allows you to define a template once and then generate new files or projects from it by filling in variables.
+
+### Usage in this Project
+
+This project uses Gruntwork Boilerplate to maintain consistency and speed up the creation of new components, particularly for Ansible roles.
+
+*   **Ansible Role Template**: A template for new Ansible roles is located in `.boilerplates/ansible-role/`. This includes a standard directory structure, placeholder files, and common configuration.
+*   **Generating New Roles**: You can use the `boilerplate` CLI (installable via `./bin/bash/setup.sh boilerplate`) to generate a new Ansible role from this template.
+
+This helps ensure that all Ansible roles follow a similar structure, making them easier to understand and maintain.

--- a/website/content/en/docs/tools/hugo.md
+++ b/website/content/en/docs/tools/hugo.md
@@ -1,0 +1,20 @@
+---
+title: "Hugo"
+weight: 4 # Fourth item in Tools Showcase
+---
+
+## Hugo
+
+[Hugo](https://gohugo.io/) is a fast and flexible static site generator written in Go. It takes content written in Markdown and uses templates to generate a complete HTML website.
+
+### Usage in this Project
+
+The documentation website for this project (the site you might be viewing this on if you're reading it online) is built using Hugo.
+
+*   **Content**: All documentation content is located in the `website/content/` directory, primarily in Markdown format.
+*   **Themes and Layouts**: The site uses a Hugo theme (located in `website/themes/`) and custom layouts to structure and style the content.
+*   **Building and Serving**:
+    *   The `./bin/bash/setup.sh hugo` script can install Hugo and start a local development server.
+    *   The GitHub Actions workflow in `.github/workflows/website.yml` automatically builds and deploys the website to GitHub Pages.
+
+Hugo's speed and simplicity make it an excellent choice for generating project documentation.

--- a/website/content/en/docs/tools/pre-commit.md
+++ b/website/content/en/docs/tools/pre-commit.md
@@ -1,0 +1,20 @@
+---
+title: "Pre-commit"
+weight: 1 # First item in Tools Showcase
+---
+
+## Pre-commit
+
+Pre-commit is a framework for managing and maintaining multi-language pre-commit hooks. It allows you to run checks on your code before you commit it, helping to enforce code style, prevent common mistakes, and ensure code quality.
+
+### Usage in this Project
+
+This project uses pre-commit hooks to automate tasks like:
+
+*   Linting various file types (e.g., YAML, Markdown, shell scripts).
+*   Checking for common Git issues (e.g., merge conflicts, large files).
+*   Ensuring consistent formatting.
+
+The configuration for pre-commit is located in the `.pre-commit-config.yaml` file at the root of the repository.
+
+To use it, you first need to install pre-commit (e.g., via `pip install pre-commit` or using the project's `./bin/bash/setup.sh pre-commit` script) and then install the git hooks with `pre-commit install`. Once installed, the checks will run automatically every time you run `git commit`.

--- a/website/data/en/docs/sidebar.yml
+++ b/website/data/en/docs/sidebar.yml
@@ -8,3 +8,14 @@
     - title: "Understanding Ansible Concepts"
     - title: Caddy
     - title: Portainer
+
+- title: Tools Showcase
+  pages:
+    - title: Pre-commit
+      path: tools/pre-commit.md # Assuming files will be in content/en/docs/tools/
+    - title: 1Password CLI
+      path: tools/1password-cli.md
+    - title: Boilerplate
+      path: tools/boilerplate.md
+    - title: Hugo
+      path: tools/hugo.md


### PR DESCRIPTION
This commit introduces a comprehensive update to the project documentation:

- Updates README.md to:
    - Add a "Development Environment Setup" section detailing the `./bin/bash/setup.sh` script and Gitpod.
    - Add a "Tools Showcase" section briefly introducing pre-commit, 1password-cli, boilerplate, and Hugo.

- Updates the Getting Started guide (`website/content/en/docs/gs1.getting_started.md`) to:
    - Include details on the `./bin/bash/setup.sh` script and Gitpod for development environment setup.

- Updates the website sidebar (`website/data/en/docs/sidebar.yml`) to:
    - Add a new "Tools Showcase" section.
    - Include links to new individual documentation pages for each featured tool.

- Creates new documentation pages for each tool in the Tools Showcase:
    - `website/content/en/docs/tools/pre-commit.md`
    - `website/content/en/docs/tools/1password-cli.md`
    - `website/content/en/docs/tools/boilerplate.md`
    - `website/content/en/docs/tools/hugo.md` Each page provides a description of the tool and its use within this project.