### PR TITLE
Add tutorial sections to tool documentation

### DIFF
--- a/website/content/en/docs/tools/1password-cli.md
+++ b/website/content/en/docs/tools/1password-cli.md
@@ -5,6 +5,17 @@ weight: 2
 
 The 1Password CLI (`op`) provides a command-line interface to interact with your 1Password vaults. It allows you to securely fetch secrets, credentials, and other sensitive information stored in 1Password, making it useful for scripting and automation.
 
+## Tutorial
+
+Here's a basic example of how to use the `op` CLI to read a secret:
+
+```bash
+# Read a secret from a specific vault
+op read "op://<YourVault>/<YourSecretItem>/password"
+```
+
+Make sure to replace `<YourVault>` and `<YourSecretItem>` with actual vault and item names or placeholders.
+
 ## Usage in this Project
 
 This project recommends using 1Password CLI for managing sensitive data like API tokens, SSH keys, and other credentials needed by Ansible and Terraform.

--- a/website/content/en/docs/tools/boilerplate.md
+++ b/website/content/en/docs/tools/boilerplate.md
@@ -7,6 +7,20 @@ weight: 3
 
 [Gruntwork Boilerplate](https://github.com/gruntwork-io/boilerplate) is a tool that helps you create and manage reusable templates for your code and configuration. It allows you to define a template once and then generate new files or projects from it by filling in variables.
 
+## Tutorial
+
+Here's an example of how to use `boilerplate` to generate a new Ansible role from the template in this project:
+
+```bash
+# Navigate to the directory where you want to create the new role
+cd ansible/roles/
+
+# Run boilerplate, pointing to the template and providing necessary variables
+boilerplate --template-url ../../.boilerplates/ansible-role/ --var role_name=my-new-role
+```
+
+Make sure the example aligns with the project's actual boilerplate usage if possible, for example, by referencing the `.boilerplates/ansible-role/` path.
+
 ## Usage in this Project
 
 This project uses Gruntwork Boilerplate to maintain consistency and speed up the creation of new components, particularly for Ansible roles.

--- a/website/content/en/docs/tools/hugo.md
+++ b/website/content/en/docs/tools/hugo.md
@@ -5,6 +5,20 @@ weight: 4
 
 [Hugo](https://gohugo.io/) is a fast and flexible static site generator written in Go. It takes content written in Markdown and uses templates to generate a complete HTML website.
 
+## Tutorial
+
+Here's a common way to use Hugo for local development:
+
+```bash
+# Navigate to the website directory
+cd website/
+
+# Start the Hugo development server
+hugo server -D
+```
+
+This command will build the site and serve it locally, usually at `http://localhost:1313/`. The `-D` flag ensures that draft content is also built.
+
 ## Usage in this Project
 
 The documentation website for this project (the site you might be viewing this on if you're reading it online) is built using Hugo.

--- a/website/content/en/docs/tools/pre-commit.md
+++ b/website/content/en/docs/tools/pre-commit.md
@@ -5,6 +5,34 @@ weight: 1
 
 Pre-commit is a framework for managing and maintaining multi-language pre-commit hooks. It allows you to run checks on your code before you commit it, helping to enforce code style, prevent common mistakes, and ensure code quality.
 
+## Tutorial
+
+Here's how you typically set up and use `pre-commit`:
+
+1.  **Install pre-commit:**
+    If you haven't already, install pre-commit. You can often do this with pip:
+    ```bash
+    pip install pre-commit
+    ```
+    Or, use the project's setup script if available:
+    ```bash
+    ./bin/bash/setup.sh pre-commit
+    ```
+
+2.  **Install the Git hooks:**
+    Navigate to your repository's root directory and run:
+    ```bash
+    pre-commit install
+    ```
+    This command installs the hooks into your `.git/hooks` directory. Now, pre-commit will run automatically before each commit.
+
+3.  **Run manually (optional):**
+    You can also run all pre-commit hooks on all files at any time:
+    ```bash
+    pre-commit run --all-files
+    ```
+    This is useful for checking all files in the repository, not just the staged ones.
+
 ## Usage in this Project
 
 This project uses pre-commit hooks to automate tasks like:


### PR DESCRIPTION
This commit adds a new "Tutorial" section to the documentation for each tool:
- 1password-cli.md
- boilerplate.md
- hugo.md
- pre-commit.md

Each tutorial section provides a concrete example of how to use the respective tool, aiming to give you a better understanding of its capabilities before learning about its specific usage within the project.