### PR TITLE
feat: Ansible collection workflow

### DIFF
--- a/.github/workflows/publish-galaxy.yml
+++ b/.github/workflows/publish-galaxy.yml
@@ -1,0 +1,64 @@
+name: Ansible Collection CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ansible/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'ansible/**'
+
+jobs:
+  validate-collection:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' # Only run for pull requests
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4 # Updated to v4
+        with:
+          path: 'repo'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5 # Updated to v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible and ansible-galaxy
+        run: |
+          pip install ansible ansible-core
+          ansible-galaxy collection build repo/ansible -v
+
+      - name: Upload collection build artifact (optional)
+        uses: actions/upload-artifact@v4 # Updated to v4
+        with:
+          name: ansible-collection-build
+          path: '*.tar.gz' # Path to the built collection file
+
+  publish-collection:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' # Only run for pushes to main
+    needs: validate-collection # Optional: make publish depend on successful validation if PRs also pushed to main
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4 # Updated to v4
+        with:
+          path: 'repo'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5 # Updated to v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible and ansible-galaxy
+        run: pip install ansible ansible-core
+
+      - name: Build and publish collection to Ansible Galaxy
+        uses: ansible/ansible-galaxy-collection@v1
+        with:
+          api_key: ${{ secrets.GALAXY_API_KEY }}
+          collection_dir: 'repo/ansible'
+          # force: true # Uncomment to allow overwriting

--- a/README.md
+++ b/README.md
@@ -115,6 +115,38 @@ Below, I've included some explainers on how I solved a specific problem when I e
 * [x] 🏃‍♂️ 2: [How to rotate Docker Secrets with Ansible](https://medium.com/itnext/rotating-docker-swarm-secrets-with-ansible-cbaddfdd8ee9?sk=886dae52f1570c251a6a664d5ee2c5fe)
 * [x] 🏃‍♂️ 3: [How to implement Pull-Request locking for Ansible](https://medium.com/itnext/safe-infrastructure-as-code-github-actions-workflow-with-a-pr-lock-27bef636f852?sk=a6615ca085348aa2543a68f9c7a41077)
 
+## Ansible Collection
+
+This repository is also available as an Ansible Collection on Ansible Galaxy, allowing you to easily reuse the roles in your own Ansible projects.
+
+**Collection Name:** `xnok.infra_bootstrap_tools`
+
+### Installation
+
+To install this collection from Ansible Galaxy, use the following command:
+
+```bash
+ansible-galaxy collection install xnok.infra_bootstrap_tools
+```
+
+### Usage
+
+Once installed, you can use the roles from this collection in your playbooks. For example, to use the `docker` role:
+
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker
+      # Optional: specify variables for the role
+      # docker_users:
+      #   - your_username
+```
+
+Refer to the `README.md` file within each role's directory (`ansible/roles/[role_name]/README.md`) for detailed information on specific roles, their variables, and dependencies.
+
+You can find the collection on Ansible Galaxy: [xnok.infra_bootstrap_tools](https://galaxy.ansible.com/xnok/infra_bootstrap_tools)
+
 ## Architecture
 
 ![](./diagrams/startup_infra_for_small_self_hosted_project.png)

--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -1,7 +1,9 @@
 namespace: "xnok"
 name: "infra_bootstrap_tools"
 version: "1.0.1"  # Incrementing version
-description: "A collection of Ansible roles for bootstrapping and managing self-hosted projects and homelabs. Includes roles for Docker, Docker Swarm, Terraform, and various utilities."
+description: >
+  A collection of Ansible roles for bootstrapping and managing self-hosted projects and homelabs. 
+  Includes roles for Docker, Docker Swarm, Terraform, and various utilities.
 readme: "README.md"
 authors:
   - "xNok <https://github.com/xNok>"
@@ -20,6 +22,5 @@ tags:
   - homelab
   - selfhosted
 repository: "https://github.com/xNok/infra-bootstrap-tools"
-issue_tracker_url: "https://github.com/xNok/infra-bootstrap-tools/issues"
 documentation: "https://github.com/xNok/infra-bootstrap-tools/blob/main/ansible/README.md"
 homepage: "https://github.com/xNok/infra-bootstrap-tools"

--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -2,7 +2,7 @@ namespace: "xnok"
 name: "infra_bootstrap_tools"
 version: "1.0.1"  # Incrementing version
 description: >
-  A collection of Ansible roles for bootstrapping and managing self-hosted projects and homelabs. 
+  A collection of Ansible roles for bootstrapping and managing self-hosted projects and homelabs.
   Includes roles for Docker, Docker Swarm, Terraform, and various utilities.
 readme: "README.md"
 authors:

--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -1,15 +1,25 @@
 namespace: "xnok"
 name: "infra_bootstrap_tools"
-description: "IaC configurations to boostrap and manage a small self-hosted project or homelab"
-version: "1.0.0"
+version: "1.0.1"  # Incrementing version
+description: "A collection of Ansible roles for bootstrapping and managing self-hosted projects and homelabs. Includes roles for Docker, Docker Swarm, Terraform, and various utilities."
 readme: "README.md"
 authors:
-    - "xNok"
+  - "xNok <https://github.com/xNok>"
 license:
-    - "MIT"
+  - "MIT"
 tags:
-    - infrastructure
-    - docker
-    - terraform
-    - digitalocean
+  - collection
+  - infrastructure
+  - automation
+  - devops
+  - docker
+  - swarm
+  - terraform
+  - cloud
+  - digitalocean
+  - homelab
+  - selfhosted
 repository: "https://github.com/xNok/infra-bootstrap-tools"
+issue_tracker_url: "https://github.com/xNok/infra-bootstrap-tools/issues"
+documentation: "https://github.com/xNok/infra-bootstrap-tools/blob/main/ansible/README.md"
+homepage: "https://github.com/xNok/infra-bootstrap-tools"

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -1,1 +1,42 @@
-# docker
+# Docker Ansible Role
+
+## Description
+
+Installs and configures Docker.
+
+## Requirements
+
+- Ansible version: 2.9
+
+## Role Variables
+
+Refer to `defaults/main.yaml` for a full list of configurable variables. Some key variables include:
+```yaml
+# defaults/main.yaml
+# docker_users: [vagrant, ubuntu]
+```
+
+This role does not use variables from `vars/main.yaml` by default.
+
+## Dependencies
+
+This role has no dependencies.
+
+## Example Playbook
+
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker
+      # docker_users:
+      #   - your_user
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/docker/meta/main.yaml
+++ b/ansible/roles/docker/meta/main.yaml
@@ -1,3 +1,18 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Installs and configures Docker.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - containerization
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/docker_swarm_app_caddy/meta/main.yaml
+++ b/ansible/roles/docker_swarm_app_caddy/meta/main.yaml
@@ -1,3 +1,21 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Deploys Caddy as a Docker Swarm service.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - swarm
+    - caddy
+    - web
+    - proxy
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/docker_swarm_app_portainer/README.md
+++ b/ansible/roles/docker_swarm_app_portainer/README.md
@@ -1,1 +1,44 @@
-# docker-swarm-app-portainer
+# Docker Swarm App Portainer Ansible Role
+
+## Description
+
+Deploys Portainer (Agent and Server) as a Docker Swarm service. Portainer is a lightweight management UI which allows you to easily manage your Docker Swarm cluster. This role uses a Jinja2 template (`portainer-agent-stack.yml.j2`) to define the Portainer stack.
+
+## Requirements
+
+-   A running Docker Swarm cluster.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# docker_swarm_app_portainer_assets_path: "{{ role_path }}/assets"
+# docker_swarm_app_portainer_host_dir: /var/data/portainer
+# docker_swarm_app_portainer_caddy: false # Set to true to expose Portainer via Caddy
+```
+The `docker_swarm_app_portainer_caddy` variable can be set to true if you are using the `docker_swarm_app_caddy` role to automatically expose Portainer with HTTPS.
+
+## Dependencies
+
+This role has no external Galaxy dependencies.
+
+## Example Playbook
+
+```yaml
+- hosts: swarm_managers
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker_swarm_app_portainer
+      # docker_swarm_app_portainer_caddy: true # If using Caddy for exposure
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/docker_swarm_app_portainer/meta/main.yaml
+++ b/ansible/roles/docker_swarm_app_portainer/meta/main.yaml
@@ -1,3 +1,20 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Deploys Portainer as a Docker Swarm service.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - swarm
+    - portainer
+    - management
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/docker_swarm_controller/README.md
+++ b/ansible/roles/docker_swarm_controller/README.md
@@ -1,1 +1,36 @@
-# docker-swarm-controller
+# Docker Swarm Controller Ansible Role
+
+## Description
+
+Initializes a Docker Swarm cluster on the target node, making it the first manager (controller) of the Swarm. It also stores the join tokens for managers and workers, which can be used by other roles to add more nodes to the Swarm.
+
+## Requirements
+
+-   Docker installed and running on the target node. (This role is often used in conjunction with a Docker installation role).
+-   Ansible version: 2.9
+
+## Role Variables
+
+This role does not have configurable variables with defaults. It uses facts set during its execution (like join tokens) that can be used by subsequent roles or plays.
+
+## Dependencies
+
+This role has no external Galaxy dependencies. It is recommended to run a Docker installation role before this one.
+
+## Example Playbook
+
+```yaml
+- hosts: swarm_controller_node
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker  # Example: ensure Docker is installed
+    - role: xnok.infra_bootstrap_tools.docker_swarm_controller
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/docker_swarm_controller/meta/main.yaml
+++ b/ansible/roles/docker_swarm_controller/meta/main.yaml
@@ -1,3 +1,19 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Initializes a Docker Swarm cluster and configures it as a controller.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - swarm
+    - controller
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/docker_swarm_manager/README.md
+++ b/ansible/roles/docker_swarm_manager/README.md
@@ -1,1 +1,48 @@
-# docker-swarm-manager
+# Docker Swarm Manager Ansible Role
+
+## Description
+
+Configures a node to join an existing Docker Swarm cluster as a manager. This role requires that a Swarm controller (initial manager) has already been initialized and its join token is available.
+
+## Requirements
+
+-   Docker installed and running on the target node.
+-   An existing Docker Swarm cluster.
+-   The Docker Swarm manager join token (typically obtained from the controller node).
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# docker_swarm_manager_inventory_group_name: 'managers'
+```
+This variable is used to identify the group of manager nodes in the inventory, which helps in fetching Swarm facts like the manager join token from the correct host (usually the first controller).
+
+The role expects the manager join token to be available as a host fact, typically set by the `docker_swarm_controller` role (e.g., `hostvars[groups[docker_swarm_manager_inventory_group_name][0]]['swarm_manager_join_token']`).
+
+## Dependencies
+
+-   `xnok.infra_bootstrap_tools.docker` (or an equivalent role to ensure Docker is installed)
+
+## Example Playbook
+
+```yaml
+- hosts: new_swarm_managers
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker
+    - role: xnok.infra_bootstrap_tools.docker_swarm_manager
+      # Ensure the controller node (e.g., in 'managers' group) has run docker_swarm_controller
+      # and the swarm_manager_join_token is available.
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/docker_swarm_manager/meta/main.yaml
+++ b/ansible/roles/docker_swarm_manager/meta/main.yaml
@@ -1,2 +1,20 @@
+galaxy_info:
+  author: xNok
+  description: Configures a node as a Docker Swarm manager.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - swarm
+    - manager
+    # Add other relevant tags
+
 dependencies:
   - docker

--- a/ansible/roles/docker_swarm_node/README.md
+++ b/ansible/roles/docker_swarm_node/README.md
@@ -1,1 +1,48 @@
-# docker-swarm-node
+# Docker Swarm Node Ansible Role
+
+## Description
+
+Configures a node to join an existing Docker Swarm cluster as a worker node. This role requires that a Swarm controller (initial manager) has already been initialized and its worker join token is available.
+
+## Requirements
+
+-   Docker installed and running on the target node.
+-   An existing Docker Swarm cluster.
+-   The Docker Swarm worker join token (typically obtained from a manager node).
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# docker_swarm_node_manager_inventory_group_name: 'managers'
+```
+This variable is used to identify the group of manager nodes in the inventory, which helps in fetching Swarm facts like the worker join token from the correct host (usually the first controller or any manager).
+
+The role expects the worker join token to be available as a host fact, typically set by the `docker_swarm_controller` role (e.g., `hostvars[groups[docker_swarm_node_manager_inventory_group_name][0]]['swarm_worker_join_token']`).
+
+## Dependencies
+
+-   `xnok.infra_bootstrap_tools.docker` (or an equivalent role to ensure Docker is installed)
+
+## Example Playbook
+
+```yaml
+- hosts: new_swarm_workers
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker
+    - role: xnok.infra_bootstrap_tools.docker_swarm_node
+      # Ensure a manager node (e.g., in 'managers' group) has run docker_swarm_controller
+      # and the swarm_worker_join_token is available.
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/docker_swarm_node/meta/main.yaml
+++ b/ansible/roles/docker_swarm_node/meta/main.yaml
@@ -1,2 +1,20 @@
+galaxy_info:
+  author: xNok
+  description: Configures a node to join a Docker Swarm cluster.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - swarm
+    - node
+    # Add other relevant tags
+
 dependencies:
   - docker

--- a/ansible/roles/docker_swarm_plugin_rclone/README.md
+++ b/ansible/roles/docker_swarm_plugin_rclone/README.md
@@ -1,1 +1,48 @@
-# docker-swarm-swarm-plugn-rclone
+# Docker Swarm Rclone Plugin Ansible Role
+
+## Description
+
+Installs and configures the Rclone Docker volume plugin (`rclone/docker-volume-rclone`) on Docker Swarm worker nodes. This allows Docker services to use rclone remotes as persistent storage volumes. The role specifically configures an rclone remote for DigitalOcean Spaces.
+
+## Requirements
+
+-   Docker installed and running on the target worker nodes.
+-   Target nodes must be part of a Docker Swarm.
+-   Environment variables `RCLONE_DIGITALOCEAN_ACCESS_KEY_ID` and `RCLONE_DIGITALOCEAN_SECRET_ACCESS_KEY` must be set on the Ansible control node.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# docker_swarm_plugin_rclone_assets_path: "{{ role_path }}/assets"
+# docker_swarm_plugin_rclone_digitalocean_access_key_id: "{{ lookup('env', 'RCLONE_DIGITALOCEAN_ACCESS_KEY_ID') }}"
+# docker_swarm_plugin_rclone_digitalocean_secret_access_key: "{{ lookup('env', 'RCLONE_DIGITALOCEAN_SECRET_ACCESS_KEY') }}"
+# docker_swarm_plugin_rclone_digitalocean_s3_enspoint: "nyc3.digitaloceanspaces.com"
+```
+These variables are used to template the `rclone.conf` file which is then pushed as a Docker Swarm config and used by the plugin.
+
+## Dependencies
+
+This role has no external Galaxy dependencies. It is assumed Docker is already installed on the target nodes.
+
+## Example Playbook
+
+```yaml
+- hosts: swarm_workers
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.docker_swarm_plugin_rclone
+      # Ensure RCLONE_DIGITALOCEAN_ACCESS_KEY_ID and RCLONE_DIGITALOCEAN_SECRET_ACCESS_KEY
+      # are set in the environment where Ansible is run.
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/docker_swarm_plugin_rclone/meta/main.yaml
+++ b/ansible/roles/docker_swarm_plugin_rclone/meta/main.yaml
@@ -1,4 +1,21 @@
-dependencies: []
-  # - docker
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Installs and configures the Rclone Docker volume plugin for Swarm.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - docker
+    - swarm
+    - rclone
+    - storage
+    - plugin
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/terraform_aws/README.md
+++ b/ansible/roles/terraform_aws/README.md
@@ -1,1 +1,67 @@
-# terraform-aws
+# Terraform AWS Ansible Role
+
+## Description
+
+Manages AWS infrastructure using Terraform. This role automates running `terraform apply` or `terraform destroy` for a Terraform configuration located within the role (in the `terraform/` directory). It supports backend configuration templating (e.g., for S3 backend) and can generate an Ansible inventory from Terraform outputs.
+
+## Requirements
+
+-   Terraform installed on the Ansible control node.
+-   AWS credentials configured for Terraform (typically via environment variables or AWS CLI profiles).
+-   The `diodonfrost.terraform` Ansible collection must be installed.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# terraform_aws_backend_config: "{{ role_path }}/assets/backend.tf" # Path to a templated backend config (e.g. backend.tf.j2)
+# terraform_aws_inventory_path: "{{ playbook_dir }}/inventory"
+# terraform_aws_inventory_prefix: "aws-swarm"
+# terraform_aws_inventory_user: "ubuntu"
+# terraform_aws_destroy: false # Set to true to run 'terraform destroy'
+```
+The Terraform files themselves are located in the `terraform/` directory within the role and include their own variables defined in `terraform/variables.tf`. These can be passed via `terraform_vars` to the `diodonfrost.terraform` role.
+
+The `assets/backend.tf.j2` template can be used to configure Terraform's S3 backend by setting appropriate variables.
+
+## Dependencies
+
+-   `diodonfrost.terraform` (Ansible Galaxy collection for running Terraform)
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+    - role: xnok.infra_bootstrap_tools.terraform_aws
+      vars:
+        # Variables for the diodonfrost.terraform role
+        terraform_project_path: "{{ role_path }}/terraform" # Path to this role's terraform files
+        terraform_state: "present" # or "absent" for destroy
+        terraform_backend_config_path: "{{ role_path }}/rendered_backend.tf" # If using templated backend
+        # terraform_vars: # Pass variables to your terraform configuration
+        #   aws_region: "us-east-1"
+        #   instance_type: "t3.micro"
+
+        # Variables for this terraform_aws role
+        terraform_aws_destroy: false
+        # Variables for backend.tf.j2 if used, e.g.:
+        # tf_s3_backend_bucket: "my-terraform-state-bucket"
+        # tf_s3_backend_key: "aws/infra/terraform.tfstate"
+        # tf_s3_backend_region: "us-east-1"
+```
+
+To destroy the infrastructure, set `terraform_aws_destroy: true` or `terraform_state: "absent"`.
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/terraform_aws/meta/main.yaml
+++ b/ansible/roles/terraform_aws/meta/main.yaml
@@ -1,9 +1,21 @@
----
 galaxy_info:
   author: xNok
-  description: Ansible role to provision infrastructure on AWS using Terraform.
-  license: MIT License
-  min_ansible_version: "2.10"
+  description: Manages AWS infrastructure using Terraform.
+  license: MIT # Ensuring this is MIT as per prompt, was MIT License
+  min_ansible_version: '2.9' # Or your desired minimum version - prompt specified 2.9, original was 2.10. Going with prompt.
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - terraform
+    - aws
+    - cloud
+    - infrastructure
+    # Add other relevant tags
 
 dependencies:
-- diodonfrost.terraform
+  - diodonfrost.terraform

--- a/ansible/roles/terraform_digitalocean/README.md
+++ b/ansible/roles/terraform_digitalocean/README.md
@@ -1,1 +1,69 @@
-# terraform-digitalocean
+# Terraform DigitalOcean Ansible Role
+
+## Description
+
+Manages DigitalOcean infrastructure using Terraform. This role automates running `terraform apply` or `terraform destroy` for a Terraform configuration located within the role (in the `terraform/` directory). It supports backend configuration and can generate an Ansible inventory from Terraform outputs.
+
+## Requirements
+
+-   Terraform installed on the Ansible control node.
+-   DigitalOcean API token configured for Terraform (typically via the `DIGITALOCEAN_TOKEN` environment variable).
+-   The `diodonfrost.terraform` Ansible collection must be installed.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# terraform_digitalocean_backend_config: "{{ role_path }}/assets/backend.tf" # Path to backend config
+# terraform_digitalocean_inventory_path: "{{ playbook_dir }}/inventory"
+# terraform_digitalocean_inventory_prefix: "do-swarm"
+# terraform_digitalocean_inventory_user: "root"
+# terraform_digitalocean_destroy: false # Set to true to run 'terraform destroy'
+```
+The Terraform files themselves are located in the `terraform/` directory within the role and include their own variables defined in `terraform/variables.tf`. These can be passed via `terraform_vars` to the `diodonfrost.terraform` role.
+The `assets/backend.tf` can be used to configure Terraform's S3-compatible backend (e.g. DigitalOcean Spaces).
+
+## Dependencies
+
+-   `diodonfrost.terraform` (Ansible Galaxy collection for running Terraform)
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+    - role: xnok.infra_bootstrap_tools.terraform_digitalocean
+      vars:
+        # Variables for the diodonfrost.terraform role
+        terraform_project_path: "{{ role_path }}/terraform" # Path to this role's terraform files
+        terraform_state: "present" # or "absent" for destroy
+        # terraform_backend_config_path: "{{ role_path }}/assets/backend.tf" # If using this backend config
+        # terraform_vars: # Pass variables to your terraform configuration
+        #   do_token: "{{ lookup('env', 'DIGITALOCEAN_TOKEN') }}"
+        #   do_region: "nyc3"
+        #   droplet_size: "s-1vcpu-1gb"
+
+        # Variables for this terraform_digitalocean role
+        terraform_digitalocean_destroy: false
+        # Variables for backend.tf if used, e.g. for DO Spaces:
+        # tf_s3_backend_endpoint: "nyc3.digitaloceanspaces.com"
+        # tf_s3_backend_access_key: "{{ lookup('env', 'DO_SPACES_ACCESS_KEY') }}"
+        # tf_s3_backend_secret_key: "{{ lookup('env', 'DO_SPACES_SECRET_KEY') }}"
+        # tf_s3_backend_bucket: "my-terraform-state-bucket"
+        # tf_s3_backend_key: "digitalocean/infra/terraform.tfstate"
+```
+
+To destroy the infrastructure, set `terraform_digitalocean_destroy: true` or `terraform_state: "absent"`.
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/terraform_digitalocean/meta/main.yaml
+++ b/ansible/roles/terraform_digitalocean/meta/main.yaml
@@ -1,9 +1,21 @@
 galaxy_info:
   author: xNok
-  description: Ansible role to provision infrastructure on DigitalOcean using Terraform.
-  license: MIT License
-  min_ansible_version: "2.10"
-
+  description: Manages DigitalOcean infrastructure using Terraform.
+  license: MIT # Ensuring this is MIT as per prompt, was MIT License
+  min_ansible_version: '2.9' # Or your desired minimum version - prompt specified 2.9, original was 2.10. Going with prompt.
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - terraform
+    - digitalocean
+    - cloud
+    - infrastructure
+    # Add other relevant tags
 
 dependencies:
-- diodonfrost.terraform
+  - diodonfrost.terraform

--- a/ansible/roles/utils_affected_roles/README.md
+++ b/ansible/roles/utils_affected_roles/README.md
@@ -1,1 +1,56 @@
-# terraform-digitalocean
+# Utils Affected Roles Ansible Role
+
+## Description
+
+Utility role to determine affected Ansible roles in a CI environment. This role compares the current branch with a target branch (e.g., main) to identify changed files and determines which Ansible roles under a specified path have been modified. This is useful for running linting or tests only on the roles that have changed.
+
+## Requirements
+
+-   Git executable available in the environment where Ansible is run.
+-   The Ansible control node should be running from within a Git repository.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# utils_affected_roles_always_run_all_roles: false # Set to true to bypass checking and always return all roles.
+# utils_affected_roles_default_branch: "main"      # The branch to compare against.
+# utils_affected_roles_roles_folder: "ansible/roles" # The folder containing Ansible roles.
+```
+The role sets a fact `affected_roles_list` which is a list of role names that have changed.
+
+## Dependencies
+
+This role has no external Galaxy dependencies.
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+    - role: xnok.infra_bootstrap_tools.utils_affected_roles
+      vars:
+        utils_affected_roles_default_branch: "production" # Compare against production branch
+  tasks:
+    - name: Display affected roles
+      ansible.builtin.debug:
+        var: affected_roles_list
+
+    - name: Run linter on affected roles
+      ansible.builtin.command: "ansible-lint {{ item }}"
+      loop: "{{ affected_roles_list }}"
+      when: affected_roles_list is defined and affected_roles_list | length > 0
+```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/utils_affected_roles/meta/main.yaml
+++ b/ansible/roles/utils_affected_roles/meta/main.yaml
@@ -1,3 +1,19 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Utility role to determine affected Ansible roles in a CI environment.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - utility
+    - ci
+    - ansible
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/utils_rotate_docker_configs/README.md
+++ b/ansible/roles/utils_rotate_docker_configs/README.md
@@ -1,1 +1,59 @@
-# utils-rotate-docker-configs
+# Utils Rotate Docker Configs Ansible Role
+
+## Description
+
+Utility role to rotate Docker Swarm configs. This role helps manage updates to Docker Swarm configurations by creating a new version of a config and then updating a specified Docker Swarm service (via its compose file) to use the new config. It's designed to allow services to pick up config changes without manual intervention.
+
+## Requirements
+
+-   Target node must be a Docker Swarm manager.
+-   Docker CLI available on the Swarm manager.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# utils_rotate_docker_configs_docker_compose_path: "{{ undef(hint='You must specify docker-compose file to update') }}"
+```
+This role requires the following variables to be passed directly during the role call:
+- `config_name`: The base name of the Docker Swarm config to rotate (e.g., `my_app_config`).
+- `config_content`: The new content for the Docker Swarm config.
+- `service_name`: The name of the Docker Swarm service that uses this config and needs to be updated.
+- `docker_compose_path`: The path to the Docker Compose file that defines the service. This variable is also in defaults but must be overridden.
+
+The role generates a new config name with a timestamp (e.g., `my_app_config_20230101120000`).
+
+## Dependencies
+
+This role has no external Galaxy dependencies.
+
+## Example Playbook
+
+```yaml
+- hosts: swarm_managers
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.utils_rotate_docker_configs
+      vars:
+        config_name: "my_caddy_config"
+        config_content: |
+          # New Caddyfile content
+          example.com {
+            reverse_proxy my_app_service:80
+          }
+        service_name: "caddy_service" # As defined in your docker-compose.yml
+        docker_compose_path: "/opt/myapp/docker-compose.yml"
+```
+
+This will create a new Docker config (e.g., `my_caddy_config_xxxxxxxxxxxxxx`), update the service `caddy_service` in `/opt/myapp/docker-compose.yml` to point to this new config, and then re-deploy the service.
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/utils_rotate_docker_configs/meta/main.yaml
+++ b/ansible/roles/utils_rotate_docker_configs/meta/main.yaml
@@ -1,3 +1,20 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Utility role to rotate Docker configs.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - utility
+    - docker
+    - secrets
+    - configs
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/utils_rotate_docker_secrets/README.md
+++ b/ansible/roles/utils_rotate_docker_secrets/README.md
@@ -1,1 +1,55 @@
-# utils-rotate-docker-secrets
+# Utils Rotate Docker Secrets Ansible Role
+
+## Description
+
+Utility role to rotate Docker Swarm secrets. This role facilitates updating Docker Swarm secrets by creating a new version of a secret and then updating a specified Docker Swarm service (via its compose file) to use the new secret. This allows services to pick up new secret versions without downtime or manual secret updates.
+
+## Requirements
+
+-   Target node must be a Docker Swarm manager.
+-   Docker CLI available on the Swarm manager.
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
+
+```yaml
+# defaults/main.yaml
+# utils_rotate_docker_secrets_docker_compose_path: "{{ undef(hint='You must specify docker-compose file to update') }}"
+```
+This role requires the following variables to be passed directly during the role call:
+- `secret_name`: The base name of the Docker Swarm secret to rotate (e.g., `my_app_db_password`).
+- `secret_value`: The new value for the Docker Swarm secret.
+- `service_name`: The name of the Docker Swarm service that uses this secret and needs to be updated.
+- `docker_compose_path`: The path to the Docker Compose file that defines the service. This variable is also in defaults but must be overridden.
+
+The role generates a new secret name with a timestamp (e.g., `my_app_db_password_20230101120000`).
+
+## Dependencies
+
+This role has no external Galaxy dependencies.
+
+## Example Playbook
+
+```yaml
+- hosts: swarm_managers
+  become: yes
+  roles:
+    - role: xnok.infra_bootstrap_tools.utils_rotate_docker_secrets
+      vars:
+        secret_name: "webapp_api_key"
+        secret_value: "new_super_secret_api_key"
+        service_name: "my_webapp_service" # As defined in your docker-compose.yml
+        docker_compose_path: "/srv/my_webapp/docker-compose.yml"
+```
+
+This will create a new Docker secret (e.g., `webapp_api_key_xxxxxxxxxxxxxx`), update the service `my_webapp_service` in `/srv/my_webapp/docker-compose.yml` to point to this new secret, and then re-deploy the service.
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/utils_rotate_docker_secrets/meta/main.yaml
+++ b/ansible/roles/utils_rotate_docker_secrets/meta/main.yaml
@@ -1,3 +1,19 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Utility role to rotate Docker secrets.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - utility
+    - docker
+    - secrets
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here

--- a/ansible/roles/utils_ssh_add/README.md
+++ b/ansible/roles/utils_ssh_add/README.md
@@ -1,30 +1,77 @@
-# utils-ssh-add
+# Utils SSH Add Ansible Role
 
-This roles allow you to setup your ansible agent on the fly, this is especially conveniant when fetching the your SSH keys from a secret vault.
+## Description
 
-## Usage
+Utility role to dynamically set up an SSH agent on the Ansible control node (localhost) and add a private SSH key to it. This is particularly useful for loading SSH keys fetched from a vault (e.g., 1Password) at runtime, allowing Ansible to use these keys for subsequent SSH connections to managed nodes without storing them decrypted on disk permanently.
+
+The role starts an `ssh-agent`, adds the provided private key, and sets facts (`ssh_agent_pid`, `ssh_auth_sock`) that can be used to configure `ansible_ssh_common_args` or environment variables for later tasks.
+
+Despite its name and original meta description, this role primarily focuses on configuring the SSH *agent* for Ansible's *client-side* operations, not on adding keys to `authorized_keys` files on *remote* servers.
+
+## Requirements
+
+-   `ssh-agent` and `ssh-add` utilities must be installed on the Ansible control node (localhost).
+-   Ansible version: 2.9
+
+## Role Variables
+
+Available variables are listed in `defaults/main.yaml`:
 
 ```yaml
-- name: Prepare localhost
+# defaults/main.yaml
+# utils_ssh_add_ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') }}/.ssh/private_key_openssh"
+```
+The key variable that needs to be provided to this role is `private_key_openssh_content`, which should contain the actual private SSH key string. The `utils_ssh_add_ansible_ssh_private_key_file` is more of a temporary path for the key content to be written before adding to agent.
+
+Key input variable:
+- `private_key_openssh_content`: (Required) The string content of the private SSH key to be added to the agent.
+
+Output facts:
+- `ssh_agent_pid`: PID of the started ssh-agent.
+- `ssh_auth_sock`: Path to the ssh-agent's socket.
+
+## Dependencies
+
+This role has no external Galaxy dependencies.
+
+## Example Playbook
+
+```yaml
+- name: Prepare SSH Agent on Localhost
   hosts: localhost
-  gather_facts: true
+  connection: local
+  gather_facts: no # Not strictly needed for this role if run early
 
   vars:
-    private_key_openssh: "{{
-        lookup('community.general.onepassword_ssh_key', 'Ansible SSH Key',
-        vault='infra-bootstrap-tools', ssh_format=true)
-        }}"
+    # Example: Fetching SSH key content from a vault or environment variable
+    my_ssh_key_content: "{{ lookup('env', 'MY_SSH_PRIVATE_KEY') }}"
+    # Or using a vault like 1Password:
+    # my_ssh_key_content: "{{ lookup('community.general.onepassword_ssh_key', 'My Ansible SSH Key', vault='myvault', ssh_format=true) }}"
+
 
   roles:
-  - utils-ssh-add
+    - role: xnok.infra_bootstrap_tools.utils_ssh_add
+      vars:
+        private_key_openssh_content: "{{ my_ssh_key_content }}"
 
-
-- name: Main Tasks
-  hosts: all
-
+- name: Use the SSH Agent for other tasks
+  hosts: my_remote_servers
+  # These vars/env would be set based on facts from the localhost play
   vars:
-    ansible_ssh_common_args: "-o 'IdentityAgent={{ hostvars['localhost']['ssh_auth_sock'] }}'"
-  environment: 
-    SSH_AGENT_PID: "{{ hostvars['localhost']['ssh_agent_pid'] }}"
+    ansible_ssh_common_args: "-o IdentityAgent={{ hostvars['localhost']['ssh_auth_sock'] }}"
+  environment:
     SSH_AUTH_SOCK: "{{ hostvars['localhost']['ssh_auth_sock'] }}"
+    # SSH_AGENT_PID: "{{ hostvars['localhost']['ssh_agent_pid'] }}" # Less commonly needed for Ansible itself
+
+  tasks:
+    - name: Ping remote server using the loaded SSH key
+      ansible.builtin.ping:
 ```
+
+## License
+
+MIT
+
+## Author Information
+
+Created by xNok.

--- a/ansible/roles/utils_ssh_add/meta/main.yaml
+++ b/ansible/roles/utils_ssh_add/meta/main.yaml
@@ -1,3 +1,19 @@
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+galaxy_info:
+  author: xNok
+  description: Utility role to add SSH keys to authorized_keys.
+  license: MIT
+  min_ansible_version: '2.9' # Or your desired minimum version
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - utility
+    - ssh
+    - security
+    # Add other relevant tags
+
+dependencies: [] # List any dependencies here


### PR DESCRIPTION
This commit updates the Ansible Galaxy GitHub Actions workflow to include a validation step for pull requests.

The workflow (`.github/workflows/publish-galaxy.yml`) now includes:
- A new `validate-collection` job that triggers on pull requests to the `main` branch (for changes in `ansible/**`). This job builds the Ansible collection to ensure its integrity before merging. The built artifact can be optionally uploaded for inspection.
- The existing `publish-collection` job is now configured to run only on direct pushes to the `main` branch.
- A `needs: validate-collection` dependency has been added to the `publish-collection` job to ensure publishing occurs only after successful validation, particularly relevant for PR merge workflows that result in a push to main.
- Updated `actions/checkout`, `actions/setup-python`, and `actions/upload-artifact` to their latest versions (v4, v5, and v4 respectively).

This change improves the CI process by catching potential issues with the Ansible collection build during the review phase, before attempting to publish to Ansible Galaxy.