### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace leakage in deploy.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-26 - Prevent Stack Trace Leaks
+**Vulnerability:** Found `traceback.print_exc()` being used in `agentic/deployment/deploy.py` to catch deployment exceptions.
+**Learning:** This exposes internal application details and logic on standard output or logs.
+**Prevention:** Always log or print a user-friendly error message or `str(e)` without exposing stack traces unless in strict debug mode. Use proper exception logging features instead of directly writing the traceback.

--- a/agentic/deployment/deploy.py
+++ b/agentic/deployment/deploy.py
@@ -209,9 +209,6 @@ def deploy_jules_workflow(prefect_api_url: str, work_pool_name: str = "default-a
         return True
     except Exception as e:
         print(f"✗ Failed to deploy workflow: {e}")
-        import traceback
-
-        traceback.print_exc()
         return False
 
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `agentic/deployment/deploy.py` used `traceback.print_exc()` in an exception handler, exposing full stack traces and potentially internal environment configuration context to output streams.
🎯 Impact: Could leak path internals, dependency trees, and internal configuration details when a deployment fails.
🔧 Fix: Replaced `import traceback` and `traceback.print_exc()` with returning `False`. A clean user-facing error message (`print(f"✗ Failed to deploy workflow: {e}")`) was already correctly logging the issue.
✅ Verification: Ran `python -m py_compile agentic/deployment/deploy.py` to ensure parsing succeeds, and passed `ruff` linters locally. Code review approved the fix. Recorded a sentinel learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9919552354161909270](https://jules.google.com/task/9919552354161909270) started by @xNok*