### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in MCP URL parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2026-05-04 - SSRF via Unvalidated MCP Server URL
+**Vulnerability:** The `MCP_SERVER_URL` in `agentic/jules/agent.py` and `agentic/workflows/jules_workflow.py` could be influenced by environment variables or arguments and passed directly to `FastMCPToolset` without validation.
+**Learning:** Initializing connections to external tools/servers using unvalidated URLs (even if sourced from environment variables) can lead to Server-Side Request Forgery (SSRF) if those inputs are ever manipulatable. This is especially dangerous in cloud environments where `FastMCPToolset` might attempt to resolve metadata IP addresses (e.g., `169.254.169.254`).
+**Prevention:** Enforce strict URL validation for all external connections, ensuring that only HTTP/HTTPS schemes are used and explicitly blocking known cloud metadata hostnames and IP addresses.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -7,9 +7,9 @@ import argparse
 import sys
 
 from pydantic_ai import Agent
-from pydantic_ai.toolset import FastMCPToolset
+from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_url, is_valid_github_issue_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,10 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_safe_mcp_url(MCP_SERVER_URL):
+        print("Error: Unsafe or invalid MCP server URL configured", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -47,3 +47,41 @@ def is_valid_github_issue_url(url: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def is_safe_mcp_url(url: str) -> bool:
+    """
+    Validates that the provided MCP URL is safe to use, mitigating SSRF risks.
+
+    Ensures the URL scheme is HTTP/HTTPS and blocks known cloud metadata
+    IP addresses and hostnames.
+
+    Args:
+        url: The MCP server URL string to validate.
+
+    Returns:
+        True if the URL is deemed safe, False otherwise.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Block known metadata IP addresses and hostnames
+        forbidden_hosts = {
+            "169.254.169.254",  # AWS / GCP / Azure metadata
+            "metadata.google.internal",  # GCP metadata
+            "169.254.170.2",  # AWS ECS metadata
+            "100.100.100.200",  # Alibaba Cloud metadata
+        }
+
+        if hostname in forbidden_hosts:
+            return False
+
+        return True
+    except Exception:
+        return False

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_url, is_valid_github_issue_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -92,9 +92,7 @@ async def assign_github_issue(agent: Agent, github_issue_url: str) -> str:
         result = await agent.run(prompt)
         return result.output
     except Exception as e:
-        raise RuntimeError(
-            "Failed to assign GitHub issue due to an internal error"
-        ) from e
+        raise RuntimeError("Failed to assign GitHub issue due to an internal error") from e
 
 
 @flow(
@@ -147,6 +145,9 @@ async def jules_agent_workflow(
 
     # Use provided or default values
     mcp_url = mcp_server_url or os.getenv("MCP_SERVER_URL", "http://localhost:8000/mcp")
+    if not is_safe_mcp_url(mcp_url):
+        raise ValueError("Unsafe or invalid MCP server URL configured")
+
     llm_model = model or os.getenv("LLM_MODEL", "google-gla:gemini-1.5-flash")
 
     print(f"Connecting to MCP server at: {mcp_url}")


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The `MCP_SERVER_URL` used to initialize `FastMCPToolset` in the agent and workflows lacked strict validation. If this value could be manipulated via environment variables or external arguments, an attacker could force the system to perform requests against unintended internal services or cloud metadata endpoints (e.g., `169.254.169.254`), leading to a Server-Side Request Forgery (SSRF) vulnerability.
**🎯 Impact:** An attacker could potentially retrieve sensitive cloud instance metadata or probe internal networks.
**🔧 Fix:** Implemented `is_safe_mcp_url` in `agentic/jules/url_validation.py` to strictly enforce `http`/`https` schemes and explicitly block known metadata hostnames and IP addresses. This validation is now enforced before connecting to the MCP server.
**✅ Verification:** 
- Successfully passed Ruff linting and formatting.
- Added scratchpad tests ensuring validation allows safe IPs and blocks known malicious IPs (which were then cleaned up).
- Tested python code locally to ensure import paths resolve correctly.

---
*PR created automatically by Jules for task [4486015653032233028](https://jules.google.com/task/4486015653032233028) started by @xNok*