### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in MCP toolset initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2026-05-05 - SSRF via FastMCPToolset Initialization
+**Vulnerability:** External MCP Server URLs were directly initialized in `FastMCPToolset` without checking if the URL points to a cloud metadata endpoint (like `169.254.169.254` or `metadata.google.internal`).
+**Learning:** Instantiating external network components using unvalidated URLs risks SSRF. FastMCPToolset makes network requests to fetch the openapi schema from the provided server URL. If an attacker controls the `MCP_SERVER_URL` via environment variables or user input, they could point it to cloud instance metadata, potentially leaking cloud credentials.
+**Prevention:** Explicitly validate URLs before using them to initialize external connections. Ensure the URL scheme is strictly restricted to expected ones (`http` or `https`) and explicitly block known cloud metadata hostnames to protect cloud environments.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -9,7 +9,7 @@ import sys
 from pydantic_ai import Agent
 from pydantic_ai.toolset import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_valid_github_issue_url, validate_mcp_server_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,10 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not validate_mcp_server_url(MCP_SERVER_URL):
+        print("Error: Invalid or unsafe MCP server URL configured", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -47,3 +47,38 @@ def is_valid_github_issue_url(url: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def validate_mcp_server_url(url: str) -> bool:
+    """
+    Validates that the provided MCP server URL is safe.
+
+    Ensures the scheme is http or https, and explicitly blocks known cloud metadata
+    hostnames/IPs to prevent SSRF vulnerabilities.
+
+    Args:
+        url: The URL string to validate.
+
+    Returns:
+        True if the URL is considered safe, False otherwise.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        # Block known cloud metadata endpoints
+        blocked_hostnames = {
+            "169.254.169.254",
+            "metadata.google.internal",
+            "169.254.169.253",  # AWS metadata v2 / GCP
+            "fd00:ec2::254",  # AWS IPv6
+        }
+
+        hostname = parsed.hostname
+        if hostname and hostname.lower() in blocked_hostnames:
+            return False
+
+        return True
+    except Exception:
+        return False

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_valid_github_issue_url, validate_mcp_server_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -31,6 +31,9 @@ async def initialize_mcp_toolset(mcp_server_url: str) -> FastMCPToolset:
         ConnectionError: If unable to connect to MCP server
     """
     import asyncio
+
+    if not validate_mcp_server_url(mcp_server_url):
+        raise ValueError("Invalid or unsafe MCP server URL provided")
 
     try:
         # ⚡ Bolt Optimization: FastMCPToolset performs synchronous network I/O


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated MCP server URLs used for initializing the `FastMCPToolset` could lead to Server-Side Request Forgery (SSRF) vulnerabilities, specifically allowing potential access to cloud metadata endpoints.
🎯 **Impact:** An attacker who controls the `MCP_SERVER_URL` environment variable or input could trick the server into making unauthorized requests to internal network services or cloud metadata instances, potentially exposing sensitive credentials.
🔧 **Fix:** Added `validate_mcp_server_url` to explicitly validate the scheme (http/https) and block known cloud instance metadata hostnames/IPs before toolset initialization.
✅ **Verification:** Logic verified locally and standalone tests confirm that metadata IPs such as `169.254.169.254` are successfully rejected.

---
*PR created automatically by Jules for task [14041950746169460629](https://jules.google.com/task/14041950746169460629) started by @xNok*