### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in MCP Toolset initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2026-05-09 - SSRF Vulnerability in MCP Toolset Initialization
+**Vulnerability:** The `mcp_server_url` input used to initialize `FastMCPToolset` in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py` was not strictly validated.
+**Learning:** Permitting unvalidated external or environment-provided URLs when establishing toolset connections (like MCP servers) poses a Server-Side Request Forgery (SSRF) risk. An attacker could potentially direct the agent to connect to cloud metadata endpoints (e.g., `169.254.169.254`) or unintended internal IP addresses.
+**Prevention:** Always validate toolset connection URLs explicitly before initialization. Enforce acceptable schemes (`http`/`https`) and explicitly deny known cloud metadata IPs or internal hostnames using robust parsing to prevent SSRF in Pydantic AI applications.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -7,9 +7,9 @@ import argparse
 import sys
 
 from pydantic_ai import Agent
-from pydantic_ai.toolset import FastMCPToolset
+from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_valid_github_issue_url, is_valid_mcp_server_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,12 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_valid_mcp_server_url(MCP_SERVER_URL):
+        print(
+            f"Error: Invalid or unsafe MCP server URL provided: {MCP_SERVER_URL}", file=sys.stderr
+        )
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -47,3 +47,35 @@ def is_valid_github_issue_url(url: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def is_valid_mcp_server_url(url: str) -> bool:
+    """
+    Validates that the provided MCP server URL is safe from SSRF.
+
+    Enforces http/https scheme and blocks known cloud metadata hostnames/IPs.
+
+    Args:
+        url: The URL string to validate.
+
+    Returns:
+        True if the URL is valid and safe, False otherwise.
+    """
+    blocked_hostnames = {
+        "169.254.169.254",
+        "metadata.google.internal",
+        "169.254.169.253",
+        "100.100.100.200",
+    }
+
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+        if not parsed.hostname:
+            return False
+        if parsed.hostname.lower() in blocked_hostnames:
+            return False
+        return True
+    except Exception:
+        return False

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_valid_github_issue_url, is_valid_mcp_server_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -31,6 +31,9 @@ async def initialize_mcp_toolset(mcp_server_url: str) -> FastMCPToolset:
         ConnectionError: If unable to connect to MCP server
     """
     import asyncio
+
+    if not is_valid_mcp_server_url(mcp_server_url):
+        raise ValueError(f"Invalid or unsafe MCP server URL provided: {mcp_server_url}")
 
     try:
         # ⚡ Bolt Optimization: FastMCPToolset performs synchronous network I/O
@@ -92,9 +95,7 @@ async def assign_github_issue(agent: Agent, github_issue_url: str) -> str:
         result = await agent.run(prompt)
         return result.output
     except Exception as e:
-        raise RuntimeError(
-            "Failed to assign GitHub issue due to an internal error"
-        ) from e
+        raise RuntimeError("Failed to assign GitHub issue due to an internal error") from e
 
 
 @flow(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `MCP_SERVER_URL` used to initialize the `FastMCPToolset` connection was not validated prior to use. This could allow a malicious actor or unsafe environmental input to force the agent into communicating with an arbitrary host, including internal endpoints and cloud metadata services.
🎯 Impact: An attacker could potentially retrieve sensitive data from internal cloud endpoints (e.g. `169.254.169.254`) or unintended internal IP addresses via SSRF.
🔧 Fix: Added strict URL validation via `is_valid_mcp_server_url` that enforces `http` or `https` schemes and explicitely blocks known cloud metadata endpoints. This is executed before initializing `FastMCPToolset`.
✅ Verification: Code syntax was verified with `py_compile`. Lints applied with `ruff check` and `ruff format`. Custom script verifying the validity of URL tests confirmed the new logic is sound.

---
*PR created automatically by Jules for task [16146205214656709922](https://jules.google.com/task/16146205214656709922) started by @xNok*