### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in MCP toolset init

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2026-05-15 - [SSRF vulnerability with FastMCPToolset]
+**Vulnerability:** The `FastMCPToolset` in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py` was initialized directly with user-provided/environmental URLs without validation.
+**Learning:** External libraries and toolsets interacting over network boundaries are susceptible to Server-Side Request Forgery (SSRF). Attackers could provide cloud metadata endpoints (e.g., `169.254.169.254`) causing internal credentials or sensitive internal infrastructure to be exposed or called by the executing agent.
+**Prevention:** Validate all URLs before passing them to external toolset initializations. Always check the scheme is restricted to `http`/`https` and block known internal/cloud metadata IP addresses and hostnames.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -9,7 +9,7 @@ import sys
 from pydantic_ai import Agent
 from pydantic_ai.toolset import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,10 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_safe_mcp_server_url(MCP_SERVER_URL):
+        print("Error: Unsafe MCP server URL", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -8,6 +8,45 @@ and SSRF attacks when processing external user inputs.
 import urllib.parse
 
 
+def is_safe_mcp_server_url(url: str) -> bool:
+    """
+    Validates that the provided MCP server URL is safe to use.
+
+    Checks that the URL scheme is http or https and blocks known
+    cloud metadata IP addresses and hostnames to prevent SSRF vulnerabilities.
+
+    Args:
+        url: The URL string to validate.
+
+    Returns:
+        True if the URL is safe, False otherwise.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Strip brackets if it's an IPv6 address
+        hostname = hostname.strip("[]")
+
+        blocked_hostnames = {
+            "169.254.169.254",
+            "metadata.google.internal",
+            "169.254.169.253",  # sometimes AWS/Google
+            "fd00:ec2::254",  # AWS IPv6
+        }
+        if hostname in blocked_hostnames:
+            return False
+
+        return True
+    except Exception:
+        return False
+
+
 def is_valid_github_issue_url(url: str) -> bool:
     """
     Validates that the provided URL is a strict GitHub issue URL.

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -92,9 +92,7 @@ async def assign_github_issue(agent: Agent, github_issue_url: str) -> str:
         result = await agent.run(prompt)
         return result.output
     except Exception as e:
-        raise RuntimeError(
-            "Failed to assign GitHub issue due to an internal error"
-        ) from e
+        raise RuntimeError("Failed to assign GitHub issue due to an internal error") from e
 
 
 @flow(
@@ -147,6 +145,10 @@ async def jules_agent_workflow(
 
     # Use provided or default values
     mcp_url = mcp_server_url or os.getenv("MCP_SERVER_URL", "http://localhost:8000/mcp")
+
+    if not is_safe_mcp_server_url(mcp_url):
+        raise ValueError("Unsafe MCP server URL provided")
+
     llm_model = model or os.getenv("LLM_MODEL", "google-gla:gemini-1.5-flash")
 
     print(f"Connecting to MCP server at: {mcp_url}")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unvalidated MCP server URLs could lead to Server-Side Request Forgery (SSRF). Attackers controlling the `MCP_SERVER_URL` or input arguments could instruct the script to connect to cloud metadata endpoints (`169.254.169.254`, etc.), potentially exposing internal credentials or services.
🎯 **Impact:** If exploited, this could allow an attacker to read cloud metadata or query internal systems via the executing agent's network privileges.
🔧 **Fix:** Implemented `is_safe_mcp_server_url` in `agentic/jules/url_validation.py` to enforce `http`/`https` schemes and explicitly block known internal metadata IP addresses and hostnames. Added validation checks in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
✅ **Verification:** A test script was run isolating the function against malicious endpoints, and the full `agentic` test suite successfully passed via `pytest`.

---
*PR created automatically by Jules for task [8848491840243106475](https://jules.google.com/task/8848491840243106475) started by @xNok*