### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in FastMCPToolset initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2026-05-16 - SSRF Vulnerability via Unvalidated MCP Server URLs
+**Vulnerability:** External input from environment (`MCP_SERVER_URL`) or user configurations could be passed directly to `FastMCPToolset` in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py` without proper validation, leading to potential Server-Side Request Forgery (SSRF) if the toolset initialization connects to malicious or internal metadata endpoints.
+**Learning:** `FastMCPToolset` makes a synchronous HTTP connection on initialization to discover tools. Allowing an attacker to specify this URL could trick the agent into accessing sensitive internal endpoints (like AWS metadata).
+**Prevention:** Enforce strong validation of `MCP_SERVER_URL` using Python's `urllib.parse` before passing it to any network-capable class. Restrict the scheme to `http/https` and explicitly block known metadata hostnames/IPs like `169.254.169.254` and `metadata.google.internal`. Ensure validations account for IPv6 handling behaviors in `urlparse`.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -9,7 +9,7 @@ import sys
 from pydantic_ai import Agent
 from pydantic_ai.toolset import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,10 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_safe_mcp_server_url(MCP_SERVER_URL):
+        print("Error: Invalid or unsafe MCP_SERVER_URL provided", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -47,3 +47,42 @@ def is_valid_github_issue_url(url: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def is_safe_mcp_server_url(url: str) -> bool:
+    """
+    Validates that the MCP server URL is safe to connect to,
+    preventing Server-Side Request Forgery (SSRF) attacks targeting
+    cloud metadata endpoints or other sensitive internal addresses.
+
+    Args:
+        url: The URL string to validate.
+
+    Returns:
+        True if the URL is safe, False otherwise.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+
+        # Enforce HTTP/HTTPS only
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Common SSRF metadata IPs and hostnames
+        # Note: urlparse strips brackets from IPv6, so fd00:ec2::254 is used instead of [fd00:ec2::254]
+        blocked_hostnames = {
+            "169.254.169.254",  # AWS/GCP/Azure/Oracle metadata
+            "metadata.google.internal",  # GCP metadata DNS
+            "fd00:ec2::254",  # AWS IPv6 metadata
+        }
+
+        if hostname in blocked_hostnames:
+            return False
+
+        return True
+    except Exception:
+        return False

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -92,9 +92,7 @@ async def assign_github_issue(agent: Agent, github_issue_url: str) -> str:
         result = await agent.run(prompt)
         return result.output
     except Exception as e:
-        raise RuntimeError(
-            "Failed to assign GitHub issue due to an internal error"
-        ) from e
+        raise RuntimeError("Failed to assign GitHub issue due to an internal error") from e
 
 
 @flow(
@@ -147,6 +145,10 @@ async def jules_agent_workflow(
 
     # Use provided or default values
     mcp_url = mcp_server_url or os.getenv("MCP_SERVER_URL", "http://localhost:8000/mcp")
+
+    if not is_safe_mcp_server_url(mcp_url):
+        raise ValueError("Invalid or unsafe MCP_SERVER_URL provided")
+
     llm_model = model or os.getenv("LLM_MODEL", "google-gla:gemini-1.5-flash")
 
     print(f"Connecting to MCP server at: {mcp_url}")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `MCP_SERVER_URL` was directly passed to `FastMCPToolset` in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py` without proper validation. This could allow an attacker to trigger Server-Side Request Forgery (SSRF) if the toolset initialization connects to malicious or internal cloud metadata endpoints.
🎯 Impact: An attacker could trick the agent into accessing sensitive internal endpoints, potentially leaking cloud credentials or internal service information.
🔧 Fix: Implemented `is_safe_mcp_server_url` in `agentic/jules/url_validation.py` using `urllib.parse` to enforce `http`/`https` schemes and explicitly block known metadata hostnames/IPs like `169.254.169.254` and `metadata.google.internal`.
✅ Verification: Tested via Python script verifying URL parsing correctly blocks restricted paths, running standard formatting/lint checks, and receiving a correct #Correct# code review assessment.

---
*PR created automatically by Jules for task [3039451358792364575](https://jules.google.com/task/3039451358792364575) started by @xNok*