### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in MCP Toolset initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+## 2026-05-03 - SSRF Vulnerability in MCP Toolset Initialization
+**Vulnerability:** External input (MCP Server URL) was passed to FastMCPToolset without validation in agent.py and jules_workflow.py.
+**Learning:** Initializing connections to external URLs directly provided by users or environment configurations can lead to Server-Side Request Forgery (SSRF), exposing internal metadata endpoints.
+**Prevention:** Always validate external URLs using strict parsing (like urllib.parse) and explicitly block known metadata endpoints (e.g., 169.254.169.254) before utilizing them for network connections.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -9,7 +9,7 @@ import sys
 from pydantic_ai import Agent
 from pydantic_ai.toolset import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_valid_github_issue_url, is_valid_mcp_server_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,12 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_valid_mcp_server_url(MCP_SERVER_URL):
+        print(
+            f"Error: Invalid or insecure MCP server URL provided: {MCP_SERVER_URL}", file=sys.stderr
+        )
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -47,3 +47,37 @@ def is_valid_github_issue_url(url: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def is_valid_mcp_server_url(url: str) -> bool:
+    """
+    Validates the MCP server URL to prevent SSRF vulnerabilities.
+
+    Args:
+        url: The MCP server URL string to validate.
+
+    Returns:
+        True if the URL is valid, False otherwise.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ["http", "https"]:
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Block known cloud metadata IP addresses and hostnames
+        blocked_hostnames = {
+            "169.254.169.254",
+            "metadata.google.internal",
+            "fd00:ec2::254",
+        }
+
+        if hostname in blocked_hostnames:
+            return False
+
+        return True
+    except Exception:
+        return False

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_valid_github_issue_url, is_valid_mcp_server_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -29,8 +29,12 @@ async def initialize_mcp_toolset(mcp_server_url: str) -> FastMCPToolset:
 
     Raises:
         ConnectionError: If unable to connect to MCP server
+        ValueError: If the MCP server URL is invalid or blocked
     """
     import asyncio
+
+    if not is_valid_mcp_server_url(mcp_server_url):
+        raise ValueError(f"Invalid or insecure MCP server URL provided: {mcp_server_url}")
 
     try:
         # ⚡ Bolt Optimization: FastMCPToolset performs synchronous network I/O
@@ -92,9 +96,7 @@ async def assign_github_issue(agent: Agent, github_issue_url: str) -> str:
         result = await agent.run(prompt)
         return result.output
     except Exception as e:
-        raise RuntimeError(
-            "Failed to assign GitHub issue due to an internal error"
-        ) from e
+        raise RuntimeError("Failed to assign GitHub issue due to an internal error") from e
 
 
 @flow(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External input for the MCP Server URL was passed directly to the `FastMCPToolset` initialization without validation.
🎯 Impact: Attackers could provide malicious URLs to perform Server-Side Request Forgery (SSRF), exposing internal or cloud metadata endpoints.
🔧 Fix: Created a new URL validation function `is_valid_mcp_server_url` that strictly checks for `http` or `https` schemes and explicitly blocks known cloud metadata addresses (e.g., `169.254.169.254`). Applied this validation before connecting to the MCP Server in both the Prefect workflow and the standalone agent script.
✅ Verification: Ran unit testing to verify that valid local URLs are permitted and metadata endpoints are successfully blocked. Checked syntax and formatted code.

---
*PR created automatically by Jules for task [2307885436071188447](https://jules.google.com/task/2307885436071188447) started by @xNok*