### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in MCP server initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2026-05-02 - SSRF Vulnerability via Unvalidated MCP Server URLs
+**Vulnerability:** External input or environment variables specifying the MCP server URL were passed to `FastMCPToolset` without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
+**Learning:** Initializing connections to external tools like MCP servers using unvalidated URLs exposes the system to Server-Side Request Forgery (SSRF) vulnerabilities, where the application could be tricked into querying internal or unintended domains (e.g., cloud metadata endpoints).
+**Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before initializing network connections. Enforce allowed schemes (`http`/`https`) and explicitly block known cloud metadata hostnames/IPs (e.g., `169.254.169.254`, `metadata.google.internal`, `fd00:ec2::254`).

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -7,9 +7,9 @@ import argparse
 import sys
 
 from pydantic_ai import Agent
-from pydantic_ai.toolset import FastMCPToolset
+from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,10 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_safe_mcp_server_url(MCP_SERVER_URL):
+        print("Error: Unsafe MCP server URL configuration", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -5,6 +5,7 @@ Centralizes security-sensitive URL validation to prevent prompt injection
 and SSRF attacks when processing external user inputs.
 """
 
+import ipaddress
 import urllib.parse
 
 
@@ -43,6 +44,35 @@ def is_valid_github_issue_url(url: str) -> bool:
         if not owner or not repo:
             return False
         if resource != "issues" or not issue_number.isdigit():
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def is_safe_mcp_server_url(url: str) -> bool:
+    """
+    Validates that the provided MCP server URL is safe from SSRF attacks.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        try:
+            ip = ipaddress.ip_address(hostname.strip("[]"))
+            if ip.is_link_local:
+                return False
+            if ip == ipaddress.ip_address("fd00:ec2::254"):
+                return False
+        except ValueError:
+            pass
+        blocked_hostnames = {"metadata.google.internal"}
+        if hostname.lower() in blocked_hostnames:
             return False
         return True
     except Exception:

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -31,6 +31,9 @@ async def initialize_mcp_toolset(mcp_server_url: str) -> FastMCPToolset:
         ConnectionError: If unable to connect to MCP server
     """
     import asyncio
+
+    if not is_safe_mcp_server_url(mcp_server_url):
+        raise ValueError(f"Invalid or unsafe MCP server URL provided: {mcp_server_url}")
 
     try:
         # ⚡ Bolt Optimization: FastMCPToolset performs synchronous network I/O
@@ -92,9 +95,7 @@ async def assign_github_issue(agent: Agent, github_issue_url: str) -> str:
         result = await agent.run(prompt)
         return result.output
     except Exception as e:
-        raise RuntimeError(
-            "Failed to assign GitHub issue due to an internal error"
-        ) from e
+        raise RuntimeError("Failed to assign GitHub issue due to an internal error") from e
 
 
 @flow(


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in MCP server initialization

🚨 Severity: CRITICAL
💡 Vulnerability: External or environment-provided URLs for the MCP server were passed directly to `FastMCPToolset` without validation.
🎯 Impact: This exposes the application to Server-Side Request Forgery (SSRF) vulnerabilities, allowing potential attackers to target internal domains or cloud metadata endpoints (e.g., `169.254.169.254`).
🔧 Fix: Implemented `is_safe_mcp_server_url` to validate the URL scheme and explicitly block known metadata hostnames/IPs. Applied this validation in both `agent.py` and `jules_workflow.py` prior to toolset initialization.
✅ Verification: Compiled successfully, passed styling/formatting checks, and manually verified that blocked endpoints throw `ValueError` while normal URLs (like `localhost`) are permitted.

---
*PR created automatically by Jules for task [2204289667063172043](https://jules.google.com/task/2204289667063172043) started by @xNok*