### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in MCP server URL handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External input (`github_issue_url`) was directly interpolated into the user prompt passed to the LLM agent without validation in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py`.
 **Learning:** Passing unsanitized URLs to an LLM exposes the system to prompt injection (where a malicious URL contains instructions overriding the agent's intent) and SSRF (where the LLM agent could be tricked into querying internal or unintended domains).
 **Prevention:** Always validate external URLs using strict parsing (like `urllib.parse`) before embedding them in prompts. Enforce allowed schemes (`https`), specific domains (`github.com`), and strictly validate path structures to ensure only intended inputs reach the LLM.
+
+## 2024-05-19 - [CRITICAL] Prevent SSRF in MCP Server URL
+**Vulnerability:** `MCP_SERVER_URL` was passed directly to `FastMCPToolset` in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py` without validation. If an attacker controls this URL, they could force the server to make requests to internal resources, including cloud metadata endpoints (SSRF).
+**Learning:** `FastMCPToolset` (and similar components that accept external URLs and make outgoing network requests) are prime targets for Server-Side Request Forgery (SSRF). Even if meant for local development or internal use, URLs sourced from environment variables or direct arguments should always be treated as untrusted and rigorously validated.
+**Prevention:** Implement validation that enforces an allowed scheme (e.g., `http`/`https`) and explicitly blocks known sensitive domains (`metadata.google.internal`) and IPs (`169.254.169.254`, `fd00:ec2::254`). IPv6 addresses must have square brackets stripped before IP evaluation.

--- a/agentic/jules/agent.py
+++ b/agentic/jules/agent.py
@@ -9,7 +9,7 @@ import sys
 from pydantic_ai import Agent
 from pydantic_ai.toolset import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 # The user has indicated that the MCP server is running locally for this demonstration.
 MCP_SERVER_URL = "http://localhost:8000/mcp"
@@ -27,6 +27,10 @@ def main():
 
     if not is_valid_github_issue_url(args.github_issue_url):
         print("Error: Invalid GitHub issue URL provided", file=sys.stderr)
+        sys.exit(1)
+
+    if not is_safe_mcp_server_url(MCP_SERVER_URL):
+        print("Error: Invalid or unsafe MCP_SERVER_URL provided", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/agentic/jules/url_validation.py
+++ b/agentic/jules/url_validation.py
@@ -5,7 +5,49 @@ Centralizes security-sensitive URL validation to prevent prompt injection
 and SSRF attacks when processing external user inputs.
 """
 
+import ipaddress
 import urllib.parse
+
+
+def is_safe_mcp_server_url(url: str) -> bool:
+    """
+    Validates that the provided MCP Server URL is safe from SSRF attacks.
+    Ensures the scheme is http/https and blocks known cloud metadata endpoints.
+
+    Args:
+        url: The URL string to validate.
+
+    Returns:
+        True if the URL appears safe, False if it is invalid or blacklisted.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Strip square brackets for IPv6 addresses
+        hostname = hostname.strip('[]')
+
+        # Block known cloud metadata domains
+        if hostname.lower() == "metadata.google.internal":
+            return False
+
+        try:
+            # Check if the hostname is an IP address
+            ip = ipaddress.ip_address(hostname)
+            # Block known cloud metadata IPs (AWS/Azure/GCP and AWS IPv6)
+            if str(ip) in ("169.254.169.254", "fd00:ec2::254"):
+                return False
+        except ValueError:
+            pass # Not an IP address, proceed
+
+        return True
+    except Exception:
+        return False
 
 
 def is_valid_github_issue_url(url: str) -> bool:

--- a/agentic/workflows/jules_workflow.py
+++ b/agentic/workflows/jules_workflow.py
@@ -13,7 +13,7 @@ from prefect import flow, task
 from pydantic_ai import Agent
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-from agentic.jules.url_validation import is_valid_github_issue_url
+from agentic.jules.url_validation import is_safe_mcp_server_url, is_valid_github_issue_url
 
 
 @task(name="initialize_mcp_toolset", retries=2, retry_delay_seconds=5)
@@ -147,6 +147,10 @@ async def jules_agent_workflow(
 
     # Use provided or default values
     mcp_url = mcp_server_url or os.getenv("MCP_SERVER_URL", "http://localhost:8000/mcp")
+
+    if not is_safe_mcp_server_url(mcp_url):
+        raise ValueError("Invalid or unsafe MCP_SERVER_URL provided")
+
     llm_model = model or os.getenv("LLM_MODEL", "google-gla:gemini-1.5-flash")
 
     print(f"Connecting to MCP server at: {mcp_url}")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `MCP_SERVER_URL` was passed directly to `FastMCPToolset` in `agentic/workflows/jules_workflow.py` and `agentic/jules/agent.py` without validation. If an attacker controls this URL via environment variables, they could cause the application to send HTTP requests to internal cloud metadata endpoints (SSRF).
🎯 Impact: An attacker could potentially retrieve sensitive data (like cloud credentials) from endpoints such as `metadata.google.internal` or `169.254.169.254`.
🔧 Fix: Implemented `is_safe_mcp_server_url` in `agentic/jules/url_validation.py` to enforce `http/https` schemes and explicitly block known cloud metadata domains and IP addresses (handling IPv6 brackets as well). Integrated this validation into both `jules_workflow.py` and `agent.py`. Documented finding in `.jules/sentinel.md`.
✅ Verification: Ran syntax checks and `ruff` (with fixes) over the `agentic/` directory. Tested the `is_safe_mcp_server_url` function to ensure it blocks `169.254.169.254`, `fd00:ec2::254`, and `metadata.google.internal`, while allowing standard local and remote HTTP/HTTPS URLs.

---
*PR created automatically by Jules for task [15723821289686845423](https://jules.google.com/task/15723821289686845423) started by @xNok*