### PR TITLE
Improve flux publish workflow

### DIFF
--- a/.github/workflows/flux-oci-publish.yml
+++ b/.github/workflows/flux-oci-publish.yml
@@ -1,5 +1,9 @@
 name: Publish Flux Artifacts
 
+# This workflow builds and publishes Flux OCI artifacts for the fleet clusters
+# and infrastructure addons when changes are merged to the main branch.
+# It uses the bin/ci/publish-flux-artifact.sh script to handle the actual publishing.
+
 on:
   push:
     branches:
@@ -40,15 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish fleet/${{ matrix.cluster }} artifact
-        run: |
-          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes/fleet/${{ matrix.cluster }}"
-          
-          flux push artifact $OCI_REPO:$(git rev-parse --short HEAD) \
-              --path="./kubernetes/fleet/${{ matrix.cluster }}" \
-              --source="${{ github.event.repository.html_url }}" \
-              --revision="$(git rev-parse HEAD)"
-          flux tag artifact $OCI_REPO:$(git rev-parse --short HEAD) --tag latest
+        run: ./bin/ci/publish-flux-artifact.sh "${{ github.repository_owner }}" "./kubernetes/fleet/${{ matrix.cluster }}" "${{ github.event.repository.html_url }}" "fleet/${{ matrix.cluster }}"
 
   publish-infra-addons:
     runs-on: ubuntu-latest
@@ -67,13 +63,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish infra-addons artifact
-        run: |
-          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes/infra-addons"
-          
-          flux push artifact $OCI_REPO:$(git rev-parse --short HEAD) \
-              --path="./kubernetes/infra-addons" \
-              --source="${{ github.event.repository.html_url }}" \
-              --revision="$(git rev-parse HEAD)"
-          flux tag artifact $OCI_REPO:$(git rev-parse --short HEAD) --tag latest
+        run: ./bin/ci/publish-flux-artifact.sh "${{ github.repository_owner }}" "./kubernetes/infra-addons" "${{ github.event.repository.html_url }}" "infra-addons"
 

--- a/.github/workflows/flux-oci-publish.yml
+++ b/.github/workflows/flux-oci-publish.yml
@@ -1,8 +1,9 @@
 name: Publish Flux Artifacts
 
 # This workflow builds and publishes Flux OCI artifacts for the fleet clusters
-# and infrastructure addons when changes are merged to the main branch.
-# It uses the bin/ci/publish-flux-artifact.sh script to handle the actual publishing.
+# and infrastructure addons on pushes to main, pull requests targeting main,
+# and manual dispatches. It uses the bin/ci/publish-flux-artifact.sh script
+# to handle the actual publishing.
 
 on:
   push:

--- a/bin/ci/publish-flux-artifact.sh
+++ b/bin/ci/publish-flux-artifact.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script is used by GitHub Actions to publish and tag Flux OCI artifacts.
+# Usage: ./bin/ci/publish-flux-artifact.sh <repository_owner> <artifact_path> <source_url> <artifact_name>
+#
+# Arguments:
+#   repository_owner: The GitHub repository owner (e.g., github.repository_owner)
+#   artifact_path: The local path to the artifact manifests (e.g., ./kubernetes/fleet/kind)
+#   source_url: The source URL of the repository (e.g., github.event.repository.html_url)
+#   artifact_name: The name of the artifact to publish (e.g., fleet/kind or infra-addons)
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <repository_owner> <artifact_path> <source_url> <artifact_name>"
+  exit 1
+fi
+
+OWNER="$1"
+ARTIFACT_PATH="$2"
+SOURCE_URL="$3"
+ARTIFACT_NAME="$4"
+
+# Ensure owner is lowercase for Docker registry compatibility
+OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+
+OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes/$ARTIFACT_NAME"
+
+SHORT_SHA=$(git rev-parse --short HEAD)
+HEAD_SHA=$(git rev-parse HEAD)
+
+echo "Publishing Flux artifact to $OCI_REPO:$SHORT_SHA..."
+
+# Push the artifact
+flux push artifact "$OCI_REPO:$SHORT_SHA" \
+    --path="$ARTIFACT_PATH" \
+    --source="$SOURCE_URL" \
+    --revision="$HEAD_SHA"
+
+# Tag the artifact as latest
+flux tag artifact "$OCI_REPO:$SHORT_SHA" --tag latest
+
+# Output summary to GitHub step summary if running in CI
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Flux Artifact Published" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Artifact Name**: \`$ARTIFACT_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**OCI Repository**: \`$OCI_REPO\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Revision**: \`$SHORT_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Source Path**: \`$ARTIFACT_PATH\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_publish_flux_artifact.bats
+++ b/bin/tests/ci/test_publish_flux_artifact.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." >/dev/null 2>&1 && pwd)"
+  export SCRIPT="$SCRIPT_DIR/ci/publish-flux-artifact.sh"
+
+  # Mock 'git'
+  mkdir -p "$TEST_TEMP_DIR/bin"
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/git"
+#!/bin/bash
+if [[ "$*" == *"rev-parse --short HEAD"* ]]; then
+  echo "abcdef1"
+elif [[ "$*" == *"rev-parse HEAD"* ]]; then
+  echo "abcdef1234567890"
+fi
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/git"
+
+  # Mock 'flux'
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/flux"
+#!/bin/bash
+echo "flux $@" >> "$TEST_TEMP_DIR/flux_calls.log"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/flux"
+
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  export GITHUB_STEP_SUMMARY="$TEST_TEMP_DIR/step_summary.md"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "script fails with insufficient arguments" {
+  run "$SCRIPT" "owner" "path" "url"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "script executes flux commands and updates summary" {
+  run "$SCRIPT" "TestOwner" "./my/path" "https://github.com/repo" "my-artifact"
+
+  [ "$status" -eq 0 ]
+
+  # Check if flux push was called correctly
+  run grep "flux push artifact oci://ghcr.io/testowner/manifests/kubernetes/my-artifact:abcdef1 --path=./my/path --source=https://github.com/repo --revision=abcdef1234567890" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  # Check if flux tag was called correctly
+  run grep "flux tag artifact oci://ghcr.io/testowner/manifests/kubernetes/my-artifact:abcdef1 --tag latest" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  # Check step summary
+  [ -f "$GITHUB_STEP_SUMMARY" ]
+  run grep "### :rocket: Flux Artifact Published" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`my-artifact\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
I have updated the `flux-oci-publish.yml` CI workflow following the guidelines provided. I extracted the inline bash commands used to push and tag Flux artifacts into a reusable script (`bin/ci/publish-flux-artifact.sh`). I added functionality to the script to append a markdown summary to `$GITHUB_STEP_SUMMARY`. I updated the workflow to call this script instead, passing in parameters as arguments. Finally, I added a mock-based `bats` test in `bin/tests/ci/test_publish_flux_artifact.bats` to ensure the script's core logic and argument handling works. The pipeline changes are documented.

---
*PR created automatically by Jules for task [4340857617915244987](https://jules.google.com/task/4340857617915244987) started by @xNok*