### PR TITLE
ci: extract kubernetes release script and add bats tests

### DIFF
--- a/.github/workflows/release-kubernetes.yml
+++ b/.github/workflows/release-kubernetes.yml
@@ -34,23 +34,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Artifact
-        run: |
-          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
-
-          # The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
-          TAG_NAME="${{ inputs.release_tag }}"
-          BUNDLE_FULL_NAME="${TAG_NAME%@*}"
-          VERSION="${TAG_NAME#*@}"
-          
-          # Remove 'kubernetes-' prefix
-          BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
-          
-          # Publish
-          flux push artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) \
-              --path="./${{ inputs.package_dir }}/$BUNDLE_NAME" \
-              --source="${{ github.event.repository.html_url }}" \
-              --revision="$(git rev-parse HEAD)"
-          
-          # Tag with version from the git tag and latest
-          flux tag artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) --tag latest --tag $VERSION
+        run: ./bin/ci/publish-kubernetes.sh "${{ github.repository_owner }}" "${{ inputs.release_tag }}" "${{ inputs.package_dir }}" "${{ github.event.repository.html_url }}"

--- a/bin/ci/publish-kubernetes.sh
+++ b/bin/ci/publish-kubernetes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <repository_owner> <release_tag> <package_dir> <source_url>"
+  exit 1
+fi
+
+OWNER="$1"
+RELEASE_TAG="$2"
+PACKAGE_DIR="$3"
+SOURCE_URL="$4"
+
+OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
+
+BUNDLE_FULL_NAME="${RELEASE_TAG%@*}"
+VERSION="${RELEASE_TAG#*@}"
+BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
+SHORT_SHA=$(git rev-parse --short HEAD)
+HEAD_SHA=$(git rev-parse HEAD)
+
+echo "Publishing Kubernetes artifact $BUNDLE_NAME to $OCI_REPO..."
+
+flux push artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" \
+    --path="./$PACKAGE_DIR/$BUNDLE_NAME" \
+    --source="$SOURCE_URL" \
+    --revision="$HEAD_SHA"
+
+flux tag artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" --tag latest --tag "$VERSION"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Kubernetes Artifact Published" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Artifact Name**: \`$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**OCI Repository**: \`$OCI_REPO/$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Revision**: \`$SHORT_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Source Path**: \`./$PACKAGE_DIR/$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_publish_kubernetes.bats
+++ b/bin/tests/ci/test_publish_kubernetes.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." >/dev/null 2>&1 && pwd)"
+  export SCRIPT="$SCRIPT_DIR/ci/publish-kubernetes.sh"
+
+  # Mock 'git'
+  mkdir -p "$TEST_TEMP_DIR/bin"
+  cat << 'MOCK' > "$TEST_TEMP_DIR/bin/git"
+#!/bin/bash
+if [[ "$*" == *"rev-parse --short HEAD"* ]]; then
+  echo "abcdef1"
+elif [[ "$*" == *"rev-parse HEAD"* ]]; then
+  echo "abcdef1234567890"
+fi
+MOCK
+  chmod +x "$TEST_TEMP_DIR/bin/git"
+
+  # Mock 'flux'
+  cat << 'MOCK' > "$TEST_TEMP_DIR/bin/flux"
+#!/bin/bash
+echo "flux $@" >> "$TEST_TEMP_DIR/flux_calls.log"
+MOCK
+  chmod +x "$TEST_TEMP_DIR/bin/flux"
+
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  export GITHUB_STEP_SUMMARY="$TEST_TEMP_DIR/step_summary.md"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "publish-kubernetes script fails with insufficient arguments" {
+  run "$SCRIPT" "owner" "tag" "dir"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "publish-kubernetes script executes flux commands and updates summary" {
+  run "$SCRIPT" "TestOwner" "kubernetes-infra-addons@1.0.0" "kubernetes" "https://github.com/repo"
+
+  [ "$status" -eq 0 ]
+
+  # Check if flux push was called correctly
+  run grep "flux push artifact oci://ghcr.io/testowner/manifests/kubernetes/infra-addons:abcdef1 --path=./kubernetes/infra-addons --source=https://github.com/repo --revision=abcdef1234567890" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  # Check if flux tag was called correctly
+  run grep "flux tag artifact oci://ghcr.io/testowner/manifests/kubernetes/infra-addons:abcdef1 --tag latest --tag 1.0.0" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  # Check step summary
+  [ -f "$GITHUB_STEP_SUMMARY" ]
+  run grep "### :rocket: Kubernetes Artifact Published" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`infra-addons\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`1.0.0\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Extracts the inline script from the `release-kubernetes.yml` workflow into `bin/ci/publish-kubernetes.sh` and provides full BATS testing for it. This aligns with the CI guidelines to keep workflows clean, testable, and producing proper summaries.

---
*PR created automatically by Jules for task [18162145248958490139](https://jules.google.com/task/18162145248958490139) started by @xNok*