### PR TITLE
ci: Refactor release-kubernetes inline script to dedicated file

### DIFF
--- a/.github/workflows/release-kubernetes.yml
+++ b/.github/workflows/release-kubernetes.yml
@@ -34,23 +34,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Artifact
-        run: |
-          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
-
-          # The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
-          TAG_NAME="${{ inputs.release_tag }}"
-          BUNDLE_FULL_NAME="${TAG_NAME%@*}"
-          VERSION="${TAG_NAME#*@}"
-          
-          # Remove 'kubernetes-' prefix
-          BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
-          
-          # Publish
-          flux push artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) \
-              --path="./${{ inputs.package_dir }}/$BUNDLE_NAME" \
-              --source="${{ github.event.repository.html_url }}" \
-              --revision="$(git rev-parse HEAD)"
-          
-          # Tag with version from the git tag and latest
-          flux tag artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) --tag latest --tag $VERSION
+        run: ./bin/ci/publish-kubernetes-release.sh "${{ github.repository_owner }}" "${{ inputs.release_tag }}" "${{ inputs.package_dir }}" "${{ github.event.repository.html_url }}"

--- a/bin/ci/publish-kubernetes-release.sh
+++ b/bin/ci/publish-kubernetes-release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script publishes a Kubernetes component release as a Flux OCI artifact
+# Usage: ./bin/ci/publish-kubernetes-release.sh <repository_owner> <release_tag> <package_dir> <source_url>
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <repository_owner> <release_tag> <package_dir> <source_url>"
+  exit 1
+fi
+
+OWNER="$1"
+RELEASE_TAG="$2"
+PACKAGE_DIR="$3"
+SOURCE_URL="$4"
+
+OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
+
+# The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
+BUNDLE_FULL_NAME="${RELEASE_TAG%@*}"
+VERSION="${RELEASE_TAG#*@}"
+
+# Remove 'kubernetes-' prefix
+BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
+
+SHORT_SHA=$(git rev-parse --short HEAD)
+HEAD_SHA=$(git rev-parse HEAD)
+
+echo "Publishing Flux artifact $BUNDLE_NAME version $VERSION to $OCI_REPO..."
+
+flux push artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" \
+    --path="./$PACKAGE_DIR/$BUNDLE_NAME" \
+    --source="$SOURCE_URL" \
+    --revision="$HEAD_SHA"
+
+flux tag artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" --tag latest --tag "$VERSION"
+
+# Output summary to GitHub step summary if running in CI
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Kubernetes Release Published" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Bundle Name**: \`$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**OCI Repository**: \`$OCI_REPO/$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Revision**: \`$SHORT_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Source Path**: \`./$PACKAGE_DIR/$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_publish_kubernetes_release.bats
+++ b/bin/tests/ci/test_publish_kubernetes_release.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Add mock flux to PATH
+  export MOCK_DIR=$(mktemp -d)
+  export PATH="${MOCK_DIR}:${PATH}"
+
+  # Create a mock flux command
+  cat << 'EOF' > "${MOCK_DIR}/flux"
+#!/usr/bin/env bash
+echo "flux $@"
+EOF
+  chmod +x "${MOCK_DIR}/flux"
+
+  # Mock git to return fake SHA
+  cat << 'EOF' > "${MOCK_DIR}/git"
+#!/usr/bin/env bash
+if [[ "$1" == "rev-parse" ]]; then
+  if [[ "$2" == "--short" ]]; then
+    echo "deadbeef"
+  else
+    echo "deadbeef1234567890abcdef"
+  fi
+else
+  echo "git $@"
+fi
+EOF
+  chmod +x "${MOCK_DIR}/git"
+
+  export GITHUB_STEP_SUMMARY="${MOCK_DIR}/summary.md"
+}
+
+teardown() {
+  rm -rf "${MOCK_DIR}"
+}
+
+@test "publish-kubernetes-release.sh requires 4 arguments" {
+  run ./bin/ci/publish-kubernetes-release.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "publish-kubernetes-release.sh publishes and tags artifact" {
+  run ./bin/ci/publish-kubernetes-release.sh "MyOrg" "kubernetes-infra-addons@1.0.0" "kubernetes" "https://github.com/myorg/repo"
+
+  [ "$status" -eq 0 ]
+
+  # Check flux push
+  [[ "$output" == *"flux push artifact oci://ghcr.io/myorg/manifests/kubernetes/infra-addons:deadbeef"* ]]
+  [[ "$output" == *"--path=./kubernetes/infra-addons"* ]]
+  [[ "$output" == *"--source=https://github.com/myorg/repo"* ]]
+  [[ "$output" == *"--revision=deadbeef1234567890abcdef"* ]]
+
+  # Check flux tag
+  [[ "$output" == *"flux tag artifact oci://ghcr.io/myorg/manifests/kubernetes/infra-addons:deadbeef --tag latest --tag 1.0.0"* ]]
+
+  # Check summary output
+  run cat "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"### :rocket: Kubernetes Release Published"* ]]
+  [[ "$output" == *"**Bundle Name**: \`infra-addons\`"* ]]
+  [[ "$output" == *"**Version**: \`1.0.0\`"* ]]
+  [[ "$output" == *"**OCI Repository**: \`oci://ghcr.io/myorg/manifests/kubernetes/infra-addons\`"* ]]
+}


### PR DESCRIPTION
This PR refactors the `release-kubernetes.yml` workflow by moving its inline script to a standalone script in `bin/ci/`.
*   Creates `bin/ci/publish-kubernetes-release.sh`
*   Replaces the inline run block in `.github/workflows/release-kubernetes.yml`.
*   Adds `bats` tests in `bin/tests/ci/test_publish_kubernetes_release.bats` to mock and verify the flux/git commands.

---
*PR created automatically by Jules for task [17081682084212195030](https://jules.google.com/task/17081682084212195030) started by @xNok*