### PR TITLE
ci: Extract inline script in release-kubernetes.yml into testable script file

### DIFF
--- a/.github/workflows/release-kubernetes.yml
+++ b/.github/workflows/release-kubernetes.yml
@@ -34,23 +34,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Artifact
-        run: |
-          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
-
-          # The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
-          TAG_NAME="${{ inputs.release_tag }}"
-          BUNDLE_FULL_NAME="${TAG_NAME%@*}"
-          VERSION="${TAG_NAME#*@}"
-          
-          # Remove 'kubernetes-' prefix
-          BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
-          
-          # Publish
-          flux push artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) \
-              --path="./${{ inputs.package_dir }}/$BUNDLE_NAME" \
-              --source="${{ github.event.repository.html_url }}" \
-              --revision="$(git rev-parse HEAD)"
-          
-          # Tag with version from the git tag and latest
-          flux tag artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) --tag latest --tag $VERSION
+        run: ./bin/ci/publish-kubernetes-release.sh "${{ github.repository_owner }}" "${{ inputs.release_tag }}" "${{ inputs.package_dir }}" "${{ github.event.repository.html_url }}"

--- a/bin/ci/publish-kubernetes-release.sh
+++ b/bin/ci/publish-kubernetes-release.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script is used by GitHub Actions to publish and tag Kubernetes components using Flux.
+# Usage: ./bin/ci/publish-kubernetes-release.sh <repository_owner> <release_tag> <package_dir> <source_url>
+#
+# Arguments:
+#   repository_owner: The GitHub repository owner (e.g., github.repository_owner)
+#   release_tag: The tag that triggered the release (e.g., kubernetes-infra-addons@1.0.0)
+#   package_dir: The directory of the package (e.g., kubernetes)
+#   source_url: The source URL of the repository (e.g., github.event.repository.html_url)
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <repository_owner> <release_tag> <package_dir> <source_url>"
+  exit 1
+fi
+
+OWNER="$1"
+RELEASE_TAG="$2"
+PACKAGE_DIR="$3"
+SOURCE_URL="$4"
+
+OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
+
+# The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
+BUNDLE_FULL_NAME="${RELEASE_TAG%@*}"
+VERSION="${RELEASE_TAG#*@}"
+
+# Remove 'kubernetes-' prefix
+BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
+
+SHORT_SHA=$(git rev-parse --short HEAD)
+HEAD_SHA=$(git rev-parse HEAD)
+
+echo "Publishing Flux artifact to $OCI_REPO/$BUNDLE_NAME:$SHORT_SHA..."
+
+# Publish
+flux push artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" \
+    --path="./${PACKAGE_DIR}/$BUNDLE_NAME" \
+    --source="$SOURCE_URL" \
+    --revision="$HEAD_SHA"
+
+# Tag with version from the git tag and latest
+flux tag artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" --tag latest --tag "$VERSION"
+
+# Output summary to GitHub step summary if running in CI
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Kubernetes Component Published" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Component Name**: \`$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**OCI Repository**: \`$OCI_REPO/$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Revision**: \`$SHORT_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_publish_kubernetes_release.bats
+++ b/bin/tests/ci/test_publish_kubernetes_release.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." >/dev/null 2>&1 && pwd)"
+  export SCRIPT="$SCRIPT_DIR/ci/publish-kubernetes-release.sh"
+
+  # Mock 'git'
+  mkdir -p "$TEST_TEMP_DIR/bin"
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/git"
+#!/bin/bash
+if [[ "$*" == *"rev-parse --short HEAD"* ]]; then
+  echo "abcdef1"
+elif [[ "$*" == *"rev-parse HEAD"* ]]; then
+  echo "abcdef1234567890"
+fi
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/git"
+
+  # Mock 'flux'
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/flux"
+#!/bin/bash
+echo "flux $@" >> "$TEST_TEMP_DIR/flux_calls.log"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/flux"
+
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  export GITHUB_STEP_SUMMARY="$TEST_TEMP_DIR/step_summary.md"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "script fails with insufficient arguments" {
+  run "$SCRIPT" "owner" "tag" "path"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "script executes flux commands and updates summary" {
+  run "$SCRIPT" "TestOwner" "kubernetes-infra-addons@1.2.3" "kubernetes" "https://github.com/repo"
+
+  [ "$status" -eq 0 ]
+
+  # Check if flux push was called correctly
+  run grep "flux push artifact oci://ghcr.io/testowner/manifests/kubernetes/infra-addons:abcdef1 --path=./kubernetes/infra-addons --source=https://github.com/repo --revision=abcdef1234567890" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  # Check if flux tag was called correctly
+  run grep "flux tag artifact oci://ghcr.io/testowner/manifests/kubernetes/infra-addons:abcdef1 --tag latest --tag 1.2.3" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  # Check step summary
+  [ -f "$GITHUB_STEP_SUMMARY" ]
+  run grep "### :rocket: Kubernetes Component Published" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`infra-addons\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`1.2.3\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}

--- a/policies/ci/no_inline_scripts.rego
+++ b/policies/ci/no_inline_scripts.rego
@@ -1,0 +1,16 @@
+package ci.no_inline_scripts
+
+deny[msg] {
+    some job_id
+    job := input.jobs[job_id]
+    some step_id
+    step := job.steps[step_id]
+
+    run_script := step.run
+
+    # Check if the run block contains a newline (is multi-line)
+    contains(run_script, "\n")
+
+    step_name := object.get(step, "name", sprintf("step %v", [step_id]))
+    msg := sprintf("Job '%v' step '%v' contains a multi-line inline script. Avoid inline scripts in CI, use script files in bin/ci instead.", [job_id, step_name])
+}


### PR DESCRIPTION
This PR refactors the `release-kubernetes.yml` CI workflow by extracting its multi-line inline script into a dedicated, reusable, and tested bash script (`bin/ci/publish-kubernetes-release.sh`).

The script has been equipped with a full BATS test suite to verify its correctness and mocked `flux` CLI commands. In addition, we introduced a new policy via `conftest` (Rego) to actively scan and prevent new multi-line scripts from creeping into CI actions, enforcing better automation practices.

---
*PR created automatically by Jules for task [13122575604136824777](https://jules.google.com/task/13122575604136824777) started by @xNok*