### PR TITLE
refactor: improve website workflow by extracting inline scripts and adding tests

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -58,21 +58,17 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: ./bin/ci/install-hugo.sh
 
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
-        run: |
-          cd website
-          hugo \
-            --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+          BASE_URL: ${{ steps.pages.outputs.base_url }}
+        run: ./bin/ci/build-hugo.sh
        
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/bin/ci/build-hugo.sh
+++ b/bin/ci/build-hugo.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo "BASE_URL is not set"
+  exit 1
+fi
+
+cd website
+hugo \
+  --gc \
+  --minify \
+  --baseURL "${BASE_URL}/"
+
+# Output summary to GitHub step summary if running in CI
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Website Built" >> "$GITHUB_STEP_SUMMARY"
+  echo "Site successfully built with Hugo." >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/ci/install-hugo.sh
+++ b/bin/ci/install-hugo.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${HUGO_VERSION:-}" ]]; then
+  echo "HUGO_VERSION is not set"
+  exit 1
+fi
+
+if [[ -z "${RUNNER_TEMP:-}" ]]; then
+  echo "RUNNER_TEMP is not set"
+  exit 1
+fi
+
+wget -O "${RUNNER_TEMP}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+sudo dpkg -i "${RUNNER_TEMP}/hugo.deb"
+
+# Output summary to GitHub step summary if running in CI
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :hammer: Hugo Installed" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Version**: \`${HUGO_VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/build-hugo.bats
+++ b/bin/tests/ci/build-hugo.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_DIR="$(mktemp -d)"
+  export PATH="${MOCK_DIR}:$PATH"
+
+  export BASE_URL="https://example.com"
+
+  # create a dummy website dir to avoid cd errors
+  mkdir -p website
+
+  # Mock hugo
+  cat << MOCK > "${MOCK_DIR}/hugo"
+#!/usr/bin/env bash
+echo "hugo called with: \$@"
+MOCK
+  chmod +x "${MOCK_DIR}/hugo"
+}
+
+teardown() {
+  rm -rf "${MOCK_DIR}"
+  rm -rf website
+}
+
+@test "build-hugo.sh fails if BASE_URL is not set" {
+  unset BASE_URL
+  run ./bin/ci/build-hugo.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"BASE_URL is not set"* ]]
+}
+
+@test "build-hugo.sh succeeds with correct env vars" {
+  export GITHUB_STEP_SUMMARY="${MOCK_DIR}/summary.md"
+  touch "$GITHUB_STEP_SUMMARY"
+
+  run ./bin/ci/build-hugo.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hugo called with: --gc --minify --baseURL https://example.com/"* ]]
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"### :rocket: Website Built"* ]]
+}

--- a/bin/tests/ci/install-hugo.bats
+++ b/bin/tests/ci/install-hugo.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_DIR="$(mktemp -d)"
+  export PATH="${MOCK_DIR}:$PATH"
+
+  export HUGO_VERSION="0.147.3"
+  export RUNNER_TEMP="/tmp"
+
+  # Mock wget
+  cat << MOCK > "${MOCK_DIR}/wget"
+#!/usr/bin/env bash
+echo "wget called with: \$@"
+MOCK
+  chmod +x "${MOCK_DIR}/wget"
+
+  # Mock sudo
+  cat << MOCK > "${MOCK_DIR}/sudo"
+#!/usr/bin/env bash
+echo "sudo called with: \$@"
+MOCK
+  chmod +x "${MOCK_DIR}/sudo"
+}
+
+teardown() {
+  rm -rf "${MOCK_DIR}"
+}
+
+@test "install-hugo.sh fails if HUGO_VERSION is not set" {
+  unset HUGO_VERSION
+  run ./bin/ci/install-hugo.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"HUGO_VERSION is not set"* ]]
+}
+
+@test "install-hugo.sh fails if RUNNER_TEMP is not set" {
+  unset RUNNER_TEMP
+  run ./bin/ci/install-hugo.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"RUNNER_TEMP is not set"* ]]
+}
+
+@test "install-hugo.sh succeeds with correct env vars" {
+  export GITHUB_STEP_SUMMARY="${MOCK_DIR}/summary.md"
+  touch "$GITHUB_STEP_SUMMARY"
+
+  run ./bin/ci/install-hugo.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"wget called with: -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.147.3/hugo_extended_0.147.3_linux-amd64.deb"* ]]
+  [[ "$output" == *"sudo called with: dpkg -i /tmp/hugo.deb"* ]]
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"### :hammer: Hugo Installed"* ]]
+}

--- a/policies/ci/no_inline_scripts.rego
+++ b/policies/ci/no_inline_scripts.rego
@@ -1,0 +1,9 @@
+package main
+
+deny[msg] {
+  step := input.jobs[_].steps[_]
+  step.run
+  run_script := trim_space(step.run)
+  contains(run_script, "\n")
+  msg = sprintf("Inline scripts are not allowed. Please move the script to bin/ci/. Found in step: %v", [step.name])
+}


### PR DESCRIPTION
This PR refactors the `website.yml` CI workflow. To adhere to CI best practices, we've replaced inline scripts with executable `.sh` scripts under `bin/ci/`. We also added comprehensive `bats` test files to test these scripts, and included step summaries logic. Lastly, a Rego policy has been added to enforce this "no inline scripts" rule across the board using `conftest`.

---
*PR created automatically by Jules for task [15311970950228255476](https://jules.google.com/task/15311970950228255476) started by @xNok*