### PR TITLE
ci: refactor website workflow to use standalone external script

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -57,22 +57,12 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      - name: Build with Hugo
+      - name: Build website with Hugo
+        run: ./bin/ci/build_website.sh
         env:
-          # For maximum backward compatibility with Hugo modules
-          HUGO_ENVIRONMENT: production
-          HUGO_ENV: production
-        run: |
-          cd website
-          hugo \
-            --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+          HUGO_VERSION: ${{ env.HUGO_VERSION }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          BASE_URL: ${{ steps.pages.outputs.base_url }}/
        
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/bin/ci/build_website.sh
+++ b/bin/ci/build_website.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HUGO_VERSION="${HUGO_VERSION:-0.147.3}"
+RUNNER_TEMP="${RUNNER_TEMP:-/tmp}"
+BASE_URL="${BASE_URL:-/}"
+
+echo "Installing Hugo CLI version ${HUGO_VERSION}..."
+wget -q -O "${RUNNER_TEMP}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+sudo dpkg -i "${RUNNER_TEMP}/hugo.deb"
+
+echo "Building website with Hugo..."
+cd website
+export HUGO_ENVIRONMENT="production"
+export HUGO_ENV="production"
+hugo --gc --minify --baseURL "${BASE_URL}"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "### Website Build Successful :rocket:" >> "$GITHUB_STEP_SUMMARY"
+    echo "- **Hugo Version:** ${HUGO_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+    echo "- **Base URL:** ${BASE_URL}" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/build_website.bats
+++ b/bin/tests/ci/build_website.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+    export MOCK_DIR="$(mktemp -d)"
+    export RUNNER_TEMP="$MOCK_DIR/tmp"
+    mkdir -p "$RUNNER_TEMP"
+    export BASE_URL="https://example.com/"
+
+    # Mock wget
+    wget() {
+        echo "Mocked wget: $@"
+        touch "${RUNNER_TEMP}/hugo.deb"
+    }
+    export -f wget
+
+    # Mock sudo dpkg
+    sudo() {
+        echo "Mocked sudo: $@"
+    }
+    export -f sudo
+
+    # Mock hugo
+    hugo() {
+        echo "Mocked hugo: $@"
+    }
+    export -f hugo
+
+    export GITHUB_STEP_SUMMARY="$MOCK_DIR/step_summary.md"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "build_website.sh executes successfully" {
+    run ./bin/ci/build_website.sh
+    [ "$status" -eq 0 ]
+
+    # Verify summary is created
+    [ -f "$GITHUB_STEP_SUMMARY" ]
+    run cat "$GITHUB_STEP_SUMMARY"
+    [[ "${lines[0]}" == "### Website Build Successful :rocket:" ]]
+}

--- a/policies/ci/no_inline_scripts.rego
+++ b/policies/ci/no_inline_scripts.rego
@@ -1,0 +1,11 @@
+package main
+
+import future.keywords.in
+
+deny[msg] {
+    some job in input.jobs
+    some step in job.steps
+    step.run
+    contains(step.run, "\n")
+    msg := sprintf("Inline scripts are not allowed. Found in step '%v'. Extract this to a script in bin/ci/.", [step.name])
+}


### PR DESCRIPTION
- Extracted inline scripts from `.github/workflows/website.yml` to `bin/ci/build_website.sh`
- Added execution summary generation to the extracted script.
- Created `bin/tests/ci/build_website.bats` to automatically test the new script using BATS.
- Created `policies/ci/no_inline_scripts.rego` to ensure CI conventions are met and block future inline scripts using Conftest.

---
*PR created automatically by Jules for task [9565475279590388857](https://jules.google.com/task/9565475279590388857) started by @xNok*