### PR TITLE
refactor(ci): extract release-kubernetes script and add inline script policy

### DIFF
--- a/.github/workflows/release-kubernetes.yml
+++ b/.github/workflows/release-kubernetes.yml
@@ -34,23 +34,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Artifact
-        run: |
-          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
-
-          # The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
-          TAG_NAME="${{ inputs.release_tag }}"
-          BUNDLE_FULL_NAME="${TAG_NAME%@*}"
-          VERSION="${TAG_NAME#*@}"
-          
-          # Remove 'kubernetes-' prefix
-          BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
-          
-          # Publish
-          flux push artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) \
-              --path="./${{ inputs.package_dir }}/$BUNDLE_NAME" \
-              --source="${{ github.event.repository.html_url }}" \
-              --revision="$(git rev-parse HEAD)"
-          
-          # Tag with version from the git tag and latest
-          flux tag artifact $OCI_REPO/$BUNDLE_NAME:$(git rev-parse --short HEAD) --tag latest --tag $VERSION
+        run: ./bin/ci/release-kubernetes.sh "${{ github.repository_owner }}" "${{ inputs.release_tag }}" "${{ inputs.package_dir }}" "${{ github.event.repository.html_url }}"

--- a/bin/ci/release-kubernetes.sh
+++ b/bin/ci/release-kubernetes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script publishes Kubernetes components as Flux OCI artifacts.
+# Usage: ./bin/ci/release-kubernetes.sh <repository_owner> <release_tag> <package_dir> <source_url>
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <repository_owner> <release_tag> <package_dir> <source_url>"
+  exit 1
+fi
+
+OWNER="$1"
+TAG_NAME="$2"
+PACKAGE_DIR="$3"
+SOURCE_URL="$4"
+
+OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+OCI_REPO="oci://ghcr.io/$OWNER_LC/manifests/kubernetes"
+
+# The tag provides the version, e.g., kubernetes-infra-addons@1.0.0
+BUNDLE_FULL_NAME="${TAG_NAME%@*}"
+VERSION="${TAG_NAME#*@}"
+
+# Remove 'kubernetes-' prefix
+BUNDLE_NAME="${BUNDLE_FULL_NAME#kubernetes-}"
+
+SHORT_SHA=$(git rev-parse --short HEAD)
+HEAD_SHA=$(git rev-parse HEAD)
+
+echo "Publishing Flux artifact to $OCI_REPO/$BUNDLE_NAME:$SHORT_SHA..."
+
+# Publish
+flux push artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" \
+    --path="./$PACKAGE_DIR/$BUNDLE_NAME" \
+    --source="$SOURCE_URL" \
+    --revision="$HEAD_SHA"
+
+# Tag with version from the git tag and latest
+flux tag artifact "$OCI_REPO/$BUNDLE_NAME:$SHORT_SHA" --tag latest --tag "$VERSION"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Kubernetes Component Published" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Component**: \`$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**OCI Repository**: \`$OCI_REPO/$BUNDLE_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Revision**: \`$SHORT_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_release_kubernetes.bats
+++ b/bin/tests/ci/test_release_kubernetes.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." >/dev/null 2>&1 && pwd)"
+  export SCRIPT="$SCRIPT_DIR/ci/release-kubernetes.sh"
+
+  # Mock 'git'
+  mkdir -p "$TEST_TEMP_DIR/bin"
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/git"
+#!/bin/bash
+if [[ "$*" == *"rev-parse --short HEAD"* ]]; then
+  echo "abcdef1"
+elif [[ "$*" == *"rev-parse HEAD"* ]]; then
+  echo "abcdef1234567890"
+fi
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/git"
+
+  # Mock 'flux'
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/flux"
+#!/bin/bash
+echo "flux $@" >> "$TEST_TEMP_DIR/flux_calls.log"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/flux"
+
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  export GITHUB_STEP_SUMMARY="$TEST_TEMP_DIR/step_summary.md"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "script fails with insufficient arguments" {
+  run "$SCRIPT" "owner" "tag" "dir"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "script executes flux commands and updates summary" {
+  run "$SCRIPT" "TestOwner" "kubernetes-infra-addons@1.0.0" "kubernetes" "https://github.com/repo"
+
+  [ "$status" -eq 0 ]
+
+  run grep "flux push artifact oci://ghcr.io/testowner/manifests/kubernetes/infra-addons:abcdef1 --path=./kubernetes/infra-addons --source=https://github.com/repo --revision=abcdef1234567890" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  run grep "flux tag artifact oci://ghcr.io/testowner/manifests/kubernetes/infra-addons:abcdef1 --tag latest --tag 1.0.0" "$TEST_TEMP_DIR/flux_calls.log"
+  [ "$status" -eq 0 ]
+
+  [ -f "$GITHUB_STEP_SUMMARY" ]
+  run grep "### :rocket: Kubernetes Component Published" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`infra-addons\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "\`1.0.0\`" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}

--- a/policies/ci/no_inline_scripts.rego
+++ b/policies/ci/no_inline_scripts.rego
@@ -1,0 +1,7 @@
+package main
+
+deny[msg] {
+  step := input.jobs[_].steps[_]
+  contains(step.run, "\n")
+  msg = sprintf("Inline multi-line scripts are not allowed. Move the script to bin/ci and run it as a single line. Found in step: %v", [step.name])
+}


### PR DESCRIPTION
This PR improves the `.github/workflows/release-kubernetes.yml` workflow by adhering to the repository's CI/CD conventions:

1. **Avoid inline scripts:** The large multi-line bash script in the `Publish Artifact` step has been extracted into `bin/ci/release-kubernetes.sh`.
2. **Workflows should produce summaries:** Logic was added to the new bash script to populate `$GITHUB_STEP_SUMMARY`.
3. **Tested scripts:** A BATS test suite was created (`bin/tests/ci/test_release_kubernetes.bats`) to mock dependencies and verify script logic.
4. **Conventions validated:** A new Rego policy (`policies/ci/no_inline_scripts.rego`) was added to ensure workflows do not contain multi-line inline scripts.

The scope was intentionally kept small, focusing only on improving this one workflow as requested. Tests were run locally using `bats` and `conftest` to ensure everything works correctly.

---
*PR created automatically by Jules for task [354925133479577141](https://jules.google.com/task/354925133479577141) started by @xNok*