### PR TITLE
ci: Refactor website workflow to extract inline scripts

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -57,22 +57,12 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      - name: Build with Hugo
+      - name: Build Website
         env:
           # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
-        run: |
-          cd website
-          hugo \
-            --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+        run: ./bin/ci/build-website.sh "${HUGO_VERSION}" "${{ runner.temp }}" "${{ steps.pages.outputs.base_url }}"
        
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/bin/ci/build-website.sh
+++ b/bin/ci/build-website.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script is used by GitHub Actions to install Hugo and build the website.
+# Usage: ./bin/ci/build-website.sh <hugo_version> <runner_temp> <base_url>
+#
+# Arguments:
+#   hugo_version: The version of Hugo to install (e.g., 0.147.3)
+#   runner_temp: The temporary directory on the runner (e.g., ${{ runner.temp }})
+#   base_url: The base URL for the website (e.g., ${{ steps.pages.outputs.base_url }})
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <hugo_version> <runner_temp> <base_url>"
+  exit 1
+fi
+
+HUGO_VERSION="$1"
+RUNNER_TEMP="$2"
+BASE_URL="$3"
+
+echo "Installing Hugo v${HUGO_VERSION}..."
+wget -O "${RUNNER_TEMP}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+sudo dpkg -i "${RUNNER_TEMP}/hugo.deb"
+
+echo "Building website with Hugo..."
+cd website
+hugo \
+  --gc \
+  --minify \
+  --baseURL "${BASE_URL}/"
+
+# Output summary to GitHub step summary if running in CI
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Website Built Successfully" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Hugo Version**: \`${HUGO_VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Base URL**: \`${BASE_URL}\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/build-website.bats
+++ b/bin/tests/ci/build-website.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_DIR="$(mktemp -d)"
+  export PATH="${MOCK_DIR}:${PATH}"
+
+  export GITHUB_STEP_SUMMARY="${MOCK_DIR}/step_summary.md"
+  touch "$GITHUB_STEP_SUMMARY"
+
+  # Mock wget
+  cat << 'MOCK_EOF' > "${MOCK_DIR}/wget"
+#!/usr/bin/env bash
+echo "mock wget $@"
+MOCK_EOF
+  chmod +x "${MOCK_DIR}/wget"
+
+  # Mock sudo
+  cat << 'MOCK_EOF' > "${MOCK_DIR}/sudo"
+#!/usr/bin/env bash
+echo "mock sudo $@"
+MOCK_EOF
+  chmod +x "${MOCK_DIR}/sudo"
+
+  # Mock cd
+  # We can't mock cd easily as an executable since it's a shell builtin.
+  # But we can override it in a function if needed. However, since the script runs in a separate bash session,
+  # the script's `cd website` will look for a `website` directory in the current working directory.
+  # We should just create a dummy website directory.
+  export MOCK_WEBSITE_DIR="$(mktemp -d)"
+
+  # Instead of relying on a physical directory, we can wrap the execution
+
+  # Mock hugo
+  cat << 'MOCK_EOF' > "${MOCK_DIR}/hugo"
+#!/usr/bin/env bash
+echo "mock hugo $@"
+MOCK_EOF
+  chmod +x "${MOCK_DIR}/hugo"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+  rm -rf "$MOCK_WEBSITE_DIR"
+}
+
+@test "build-website.sh fails when missing arguments" {
+  run ./bin/ci/build-website.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "build-website.sh executes successfully and outputs summary" {
+  # Create a wrapper to intercept cd website
+  cat << 'WRAPPER_EOF' > "${MOCK_DIR}/test_wrapper.sh"
+#!/usr/bin/env bash
+cd() {
+  echo "mock cd $@"
+}
+export -f cd
+./bin/ci/build-website.sh "0.147.3" "/tmp/runner" "https://example.com"
+WRAPPER_EOF
+  chmod +x "${MOCK_DIR}/test_wrapper.sh"
+
+  run "${MOCK_DIR}/test_wrapper.sh"
+
+  echo "$output"
+  [ "$status" -eq 0 ]
+
+  # Check if mock commands were called
+  [[ "$output" == *"mock wget -O /tmp/runner/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.147.3/hugo_extended_0.147.3_linux-amd64.deb"* ]]
+  [[ "$output" == *"mock sudo dpkg -i /tmp/runner/hugo.deb"* ]]
+  [[ "$output" == *"mock cd website"* ]]
+  [[ "$output" == *"mock hugo --gc --minify --baseURL https://example.com/"* ]]
+
+  # Check if summary was populated
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"### :rocket: Website Built Successfully"* ]]
+  [[ "$output" == *"**Hugo Version**: \`0.147.3\`"* ]]
+  [[ "$output" == *"**Base URL**: \`https://example.com\`"* ]]
+}

--- a/policies/ci/inline_scripts.rego
+++ b/policies/ci/inline_scripts.rego
@@ -1,0 +1,22 @@
+package main
+
+# Deny any run step that contains a newline, suggesting it is a multiline inline script
+deny[msg] {
+  # Match all jobs in the workflow
+  some job_id
+  job := input.jobs[job_id]
+
+  # Match all steps in the job
+  some step_index
+  step := job.steps[step_index]
+
+  # Check if the step has a "run" command
+  step.run
+
+  # If the run command contains a newline, it's a multiline script
+  contains(step.run, "\n")
+
+  # Generate the error message
+  step_name := object.get(step, "name", sprintf("step %v", [step_index]))
+  msg := sprintf("Job '%v' step '%v' contains a multiline inline script. Please extract this into a dedicated script in the `bin/ci` directory.", [job_id, step_name])
+}


### PR DESCRIPTION
Refactor website workflow to extract inline scripts

* Extracted the Hugo installation and build steps from `.github/workflows/website.yml` into a dedicated bash script `bin/ci/build-website.sh`.
* Included logic in the bash script to populate `$GITHUB_STEP_SUMMARY`.
* Wrote `bin/tests/ci/build-website.bats` to properly unit test the shell script.
* Created a conftest rego policy `policies/ci/inline_scripts.rego` to enforce that CI runs steps shouldn't be multiline inline scripts.

---
*PR created automatically by Jules for task [11671686418095506477](https://jules.google.com/task/11671686418095506477) started by @xNok*