### PR TITLE
ci: Refactor ansible docker swarm workflow to extract inline scripts

### DIFF
--- a/.github/workflows/ansible-play-docker-swarm.yml
+++ b/.github/workflows/ansible-play-docker-swarm.yml
@@ -43,9 +43,7 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Run ansible-lint
-        run: |
-          make install-collection
-          ansible-lint ansible
+        run: ./bin/ci/run-ansible-lint.sh
 
   lock:
     # The type of runner that the job will run on
@@ -92,8 +90,7 @@ jobs:
         run: echo "$INVENTORY" > inventory/extra
 
       - name: run playbook
-        run: |
-          ansible-playbook -i ansible/playbooks/inventory ansible/playbooks/main.yml
+        run: ./bin/ci/run-ansible-playbook.sh
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/bin/ci/run-ansible-lint.sh
+++ b/bin/ci/run-ansible-lint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+make install-collection
+ansible-lint ansible
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :white_check_mark: Ansible Lint Passed" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/ci/run-ansible-playbook.sh
+++ b/bin/ci/run-ansible-playbook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ansible-playbook -i ansible/playbooks/inventory ansible/playbooks/main.yml
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Ansible Playbook Executed Successfully" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_run_ansible_lint.bats
+++ b/bin/tests/ci/test_run_ansible_lint.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." >/dev/null 2>&1 && pwd)"
+  export SCRIPT="$SCRIPT_DIR/ci/run-ansible-lint.sh"
+
+  mkdir -p "$TEST_TEMP_DIR/bin"
+
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/make"
+#!/bin/bash
+echo "make $@" >> "$TEST_TEMP_DIR/make_calls.log"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/make"
+
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/ansible-lint"
+#!/bin/bash
+echo "ansible-lint $@" >> "$TEST_TEMP_DIR/ansible_lint_calls.log"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/ansible-lint"
+
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  export GITHUB_STEP_SUMMARY="$TEST_TEMP_DIR/step_summary.md"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "run-ansible-lint.sh executes make and ansible-lint and updates summary" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep "make install-collection" "$TEST_TEMP_DIR/make_calls.log"
+  [ "$status" -eq 0 ]
+
+  run grep "ansible-lint ansible" "$TEST_TEMP_DIR/ansible_lint_calls.log"
+  [ "$status" -eq 0 ]
+
+  [ -f "$GITHUB_STEP_SUMMARY" ]
+  run grep "### :white_check_mark: Ansible Lint Passed" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}

--- a/bin/tests/ci/test_run_ansible_playbook.bats
+++ b/bin/tests/ci/test_run_ansible_playbook.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." >/dev/null 2>&1 && pwd)"
+  export SCRIPT="$SCRIPT_DIR/ci/run-ansible-playbook.sh"
+
+  mkdir -p "$TEST_TEMP_DIR/bin"
+
+  cat << 'EOF' > "$TEST_TEMP_DIR/bin/ansible-playbook"
+#!/bin/bash
+echo "ansible-playbook $@" >> "$TEST_TEMP_DIR/ansible_playbook_calls.log"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/ansible-playbook"
+
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  export GITHUB_STEP_SUMMARY="$TEST_TEMP_DIR/step_summary.md"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "run-ansible-playbook.sh executes ansible-playbook and updates summary" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep "ansible-playbook -i ansible/playbooks/inventory ansible/playbooks/main.yml" "$TEST_TEMP_DIR/ansible_playbook_calls.log"
+  [ "$status" -eq 0 ]
+
+  [ -f "$GITHUB_STEP_SUMMARY" ]
+  run grep "### :rocket: Ansible Playbook Executed Successfully" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This pull request addresses the requirement to remove inline scripts from CI workflows and improve script testability.

Changes made:
- Extracted inline `ansible-lint` commands into `bin/ci/run-ansible-lint.sh`.
- Extracted inline `ansible-playbook` commands into `bin/ci/run-ansible-playbook.sh`.
- Both new scripts output status updates to `$GITHUB_STEP_SUMMARY`.
- Replaced the inline `run` commands in `.github/workflows/ansible-play-docker-swarm.yml` with calls to the new scripts.
- Added BATS tests for both new scripts in `bin/tests/ci/` using mock binaries to verify their execution flow without side effects.
- Verified the workflow against `policies/ci/inline_scripts.rego` using `conftest`.

---
*PR created automatically by Jules for task [8185181413968008788](https://jules.google.com/task/8185181413968008788) started by @xNok*