### PR TITLE
ci: Extract inline scripts from release-stacks workflow

### DIFF
--- a/.github/workflows/release-stacks.yml
+++ b/.github/workflows/release-stacks.yml
@@ -52,52 +52,23 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] || [ "${{ github.event_name }}" == "workflow_call" ]; then
-            TAG="${{ inputs.release_tag || github.event.inputs.release_tag }}"
-          else
-            TAG="${{ github.event.release.tag_name }}"
-          fi
-          # Extract version from tag (format: stacks@1.0.3)
-          VERSION=$(echo "$TAG" | sed 's/^.*@//')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.release_tag || github.event.inputs.release_tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: ./bin/ci/extract-version.sh "$EVENT_NAME" "$INPUT_TAG" "$RELEASE_TAG"
 
       - name: Create stack archives
-        run: |
-          DIR="${{ inputs.stacks_dir || github.event.inputs.stacks_dir || 'stacks' }}"
-          VERSION="${{ steps.version.outputs.version }}"
-          DIST_DIR="$GITHUB_WORKSPACE/dist"
-          mkdir -p "$DIST_DIR"
-
-          # Create individual stack archives
-          for stack in "$DIR"/*/; do
-            if [ -d "$stack" ] && [ "$(basename "$stack")" != "node_modules" ]; then
-              stack_name=$(basename "$stack")
-              echo "Creating archive for $stack_name"
-              (cd "$(dirname "$stack")" && zip -r "$DIST_DIR/${stack_name}-${VERSION}.zip" "$stack_name" -x "*/node_modules/*" "*.git/*")
-            fi
-          done
-
-          # Create a complete stacks archive
-          echo "Creating complete stacks archive"
-          (cd "$DIR" && zip -r "$DIST_DIR/infra-bootstrap-tools-stacks-${VERSION}.zip" . -x "node_modules/*" "*.git/*" "*/node_modules/*")
-
-          ls -lh "$DIST_DIR/"
+        env:
+          DIR: ${{ inputs.stacks_dir || github.event.inputs.stacks_dir || 'stacks' }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_DIR: ${{ github.workspace }}/dist
+        run: ./bin/ci/package-stacks.sh "$DIR" "$VERSION" "$DIST_DIR"
 
       - name: Upload archives to release
         if: ${{ !(inputs.dry_run || github.event.inputs.dry_run) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          DIST_DIR="$GITHUB_WORKSPACE/dist"
-
-          if gh release view "$TAG" > /dev/null 2>&1; then
-            gh release upload "$TAG" \
-              "$DIST_DIR"/*.zip \
-              --clobber
-          else
-            echo "No GitHub Release found for tag $TAG, skipping upload"
-          fi
+          TAG: ${{ steps.version.outputs.tag }}
+          DIST_DIR: ${{ github.workspace }}/dist
+        run: ./bin/ci/upload-stacks-release.sh "$TAG" "$DIST_DIR"

--- a/bin/ci/extract-version-from-tag.sh
+++ b/bin/ci/extract-version-from-tag.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <event_name> <tag>"
+  exit 1
+fi
+
+EVENT_NAME="$1"
+TAG="$2"
+
+# Extract version from tag (format: package@1.0.0 or v1.0.0 or just 1.0.0)
+VERSION=$(echo "$TAG" | sed 's/^.*@//' | sed 's/^v//')
+
+# GitHub Actions standard mechanism to set outputs
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+  echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+fi
+
+echo "Version: $VERSION"

--- a/bin/ci/extract-version.sh
+++ b/bin/ci/extract-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+EVENT_NAME="$1"
+INPUT_TAG="$2"
+RELEASE_TAG="$3"
+if [ "$EVENT_NAME" == "workflow_dispatch" ] || [ "$EVENT_NAME" == "workflow_call" ]; then
+  ./bin/ci/extract-version-from-tag.sh "$EVENT_NAME" "$INPUT_TAG"
+else
+  ./bin/ci/extract-version-from-tag.sh "$EVENT_NAME" "$RELEASE_TAG"
+fi

--- a/bin/ci/package-stacks.sh
+++ b/bin/ci/package-stacks.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <stacks_dir> <version> <dist_dir>"
+  exit 1
+fi
+
+DIR="$1"
+VERSION="$2"
+DIST_DIR="$3"
+
+mkdir -p "$DIST_DIR"
+
+# Create individual stack archives
+for stack in "$DIR"/*/; do
+  if [ -d "$stack" ] && [ "$(basename "$stack")" != "node_modules" ]; then
+    stack_name=$(basename "$stack")
+    echo "Creating archive for $stack_name"
+    (cd "$(dirname "$stack")" && zip -r "$DIST_DIR/${stack_name}-${VERSION}.zip" "$stack_name" -x "*/node_modules/*" "*.git/*")
+  fi
+done
+
+# Create a complete stacks archive
+echo "Creating complete stacks archive"
+(cd "$DIR" && zip -r "$DIST_DIR/infra-bootstrap-tools-stacks-${VERSION}.zip" . -x "node_modules/*" "*.git/*" "*/node_modules/*")
+
+ls -lh "$DIST_DIR/"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :package: Stacks Packaged" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/ci/upload-stacks-release.sh
+++ b/bin/ci/upload-stacks-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <tag> <dist_dir>"
+  exit 1
+fi
+
+TAG="$1"
+DIST_DIR="$2"
+
+if gh release view "$TAG" > /dev/null 2>&1; then
+  gh release upload "$TAG" \
+    "$DIST_DIR"/*.zip \
+    --clobber
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "### :rocket: Stacks Uploaded" >> "$GITHUB_STEP_SUMMARY"
+    echo "**Release Tag**: \`$TAG\`" >> "$GITHUB_STEP_SUMMARY"
+  fi
+else
+  echo "No GitHub Release found for tag $TAG, skipping upload"
+fi

--- a/bin/tests/ci/test_extract_version.bats
+++ b/bin/tests/ci/test_extract_version.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_OUTPUT="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+}
+
+@test "extract version handles package@1.0.0" {
+  run ./bin/ci/extract-version-from-tag.sh "workflow_dispatch" "package@1.0.0"
+  [ "$status" -eq 0 ]
+  grep -q "version=1.0.0" "$GITHUB_OUTPUT"
+}
+
+@test "extract version handles v1.0.0" {
+  run ./bin/ci/extract-version-from-tag.sh "workflow_dispatch" "v1.0.0"
+  [ "$status" -eq 0 ]
+  grep -q "version=1.0.0" "$GITHUB_OUTPUT"
+}
+
+@test "extract version handler chooses correct tag based on event" {
+  run ./bin/ci/extract-version.sh "workflow_dispatch" "input@1.0.0" "release@2.0.0"
+  [ "$status" -eq 0 ]
+  grep -q "version=1.0.0" "$GITHUB_OUTPUT"
+
+  run ./bin/ci/extract-version.sh "release" "input@1.0.0" "release@2.0.0"
+  [ "$status" -eq 0 ]
+  grep -q "version=2.0.0" "$GITHUB_OUTPUT"
+}

--- a/bin/tests/ci/test_package_stacks.bats
+++ b/bin/tests/ci/test_package_stacks.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_DIR="$(mktemp -d)"
+  export DIST_DIR="$(mktemp -d)"
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+
+  mkdir -p "$TEST_DIR/stack-a"
+  echo "test" > "$TEST_DIR/stack-a/file.txt"
+
+  mkdir -p "$TEST_DIR/stack-b"
+  echo "test" > "$TEST_DIR/stack-b/file.txt"
+
+  # create a node_modules which should be ignored
+  mkdir -p "$TEST_DIR/stack-b/node_modules"
+  echo "test" > "$TEST_DIR/stack-b/node_modules/file.txt"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+  rm -rf "$DIST_DIR"
+  rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "package stacks creates correct zips" {
+  run ./bin/ci/package-stacks.sh "$TEST_DIR" "1.0.0" "$DIST_DIR"
+  [ "$status" -eq 0 ]
+
+  # Check individual stack zip
+  [ -f "$DIST_DIR/stack-a-1.0.0.zip" ]
+  [ -f "$DIST_DIR/stack-b-1.0.0.zip" ]
+
+  # Check combined stack zip
+  [ -f "$DIST_DIR/infra-bootstrap-tools-stacks-1.0.0.zip" ]
+
+  # Check output summary
+  grep -q "Stacks Packaged" "$GITHUB_STEP_SUMMARY"
+}

--- a/bin/tests/ci/test_upload_stacks_release.bats
+++ b/bin/tests/ci/test_upload_stacks_release.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PATH="$BATS_TEST_DIRNAME/mocks:$PATH"
+  mkdir -p "$BATS_TEST_DIRNAME/mocks"
+
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export DIST_DIR="$(mktemp -d)"
+  touch "$DIST_DIR/test.zip"
+
+  cat << 'MOCK' > "$BATS_TEST_DIRNAME/mocks/gh"
+#!/usr/bin/env bash
+if [[ "$1" == "release" && "$2" == "view" ]]; then
+  if [[ "$3" == "valid@1.0.0" ]]; then
+    exit 0
+  else
+    exit 1
+  fi
+elif [[ "$1" == "release" && "$2" == "upload" ]]; then
+  echo "mock upload"
+  exit 0
+fi
+MOCK
+  chmod +x "$BATS_TEST_DIRNAME/mocks/gh"
+}
+
+teardown() {
+  rm -rf "$BATS_TEST_DIRNAME/mocks"
+  rm -rf "$DIST_DIR"
+  rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "upload stacks uploads if release exists" {
+  run ./bin/ci/upload-stacks-release.sh "valid@1.0.0" "$DIST_DIR"
+  [ "$status" -eq 0 ]
+  grep -q "mock upload" <<< "$output"
+  grep -q "Stacks Uploaded" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "upload stacks skips if release does not exist" {
+  run ./bin/ci/upload-stacks-release.sh "invalid@1.0.0" "$DIST_DIR"
+  [ "$status" -eq 0 ]
+  grep -q "skipping upload" <<< "$output"
+}


### PR DESCRIPTION
This pull request extracts several inline multiline Bash scripts from the `.github/workflows/release-stacks.yml` CI/CD workflow into dedicated, reusable files located inside `bin/ci/`. This improves code reuse and ensures compliance with the internal convention enforced via `inline_scripts.rego` and `conftest`. 

Included in this update:
- **`bin/ci/extract-version.sh`**: Helper dispatch script.
- **`bin/ci/extract-version-from-tag.sh`**: Logic to correctly extract versions from tags format.
- **`bin/ci/package-stacks.sh`**: Handles creation of combined and individual zip files containing stacks. Outputs to a step summary.
- **`bin/ci/upload-stacks-release.sh`**: Safely performs GitHub CLI release uploads while generating GitHub Action step summaries.

All new scripts are accompanied by robust BATS test suites to prevent regressions.

---
*PR created automatically by Jules for task [16795623252322869856](https://jules.google.com/task/16795623252322869856) started by @xNok*