### PR TITLE
refactor(ci): extract inline scripts in ansible-play-docker-swarm

### DIFF
--- a/.github/workflows/ansible-play-docker-swarm.yml
+++ b/.github/workflows/ansible-play-docker-swarm.yml
@@ -43,9 +43,7 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Run ansible-lint
-        run: |
-          make install-collection
-          ansible-lint ansible
+        run: ./bin/ci/ansible-lint.sh
 
   lock:
     # The type of runner that the job will run on
@@ -92,9 +90,7 @@ jobs:
         run: echo "$INVENTORY" > inventory/extra
 
       - name: run playbook
-        run: |
-          ansible-playbook -i ansible/playbooks/inventory ansible/playbooks/main.yml
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
+        run: ./bin/ci/run-playbook.sh

--- a/bin/ci/ansible-lint.sh
+++ b/bin/ci/ansible-lint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "### Ansible Lint Run :rocket:" >> "$GITHUB_STEP_SUMMARY"
+echo "Running make install-collection and ansible-lint ansible..." >> "$GITHUB_STEP_SUMMARY"
+
+make install-collection
+ansible-lint ansible
+
+echo "Lint completed successfully :heavy_check_mark:" >> "$GITHUB_STEP_SUMMARY"

--- a/bin/ci/run-playbook.sh
+++ b/bin/ci/run-playbook.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "### Ansible Playbook Run :rocket:" >> "$GITHUB_STEP_SUMMARY"
+echo "Running main playbook on inventory..." >> "$GITHUB_STEP_SUMMARY"
+
+ansible-playbook -i ansible/playbooks/inventory ansible/playbooks/main.yml
+
+echo "Playbook execution completed successfully :heavy_check_mark:" >> "$GITHUB_STEP_SUMMARY"

--- a/bin/tests/ci/ansible-lint.bats
+++ b/bin/tests/ci/ansible-lint.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+setup() {
+    export MOCK_BIN_DIR="$(mktemp -d)"
+    export PATH="$MOCK_BIN_DIR:$PATH"
+
+    cat << 'MOCK' > "$MOCK_BIN_DIR/make"
+#!/bin/bash
+echo "make $*"
+MOCK
+    chmod +x "$MOCK_BIN_DIR/make"
+
+    cat << 'MOCK' > "$MOCK_BIN_DIR/ansible-lint"
+#!/bin/bash
+echo "ansible-lint $*"
+MOCK
+    chmod +x "$MOCK_BIN_DIR/ansible-lint"
+
+    export GITHUB_STEP_SUMMARY="$(mktemp)"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN_DIR"
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "ansible-lint.sh calls make install-collection and ansible-lint ansible" {
+    run ./bin/ci/ansible-lint.sh
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" == "make install-collection" ]]
+    [[ "${lines[1]}" == "ansible-lint ansible" ]]
+    grep -q "Ansible Lint Run" "$GITHUB_STEP_SUMMARY"
+}

--- a/bin/tests/ci/run-playbook.bats
+++ b/bin/tests/ci/run-playbook.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+    export MOCK_BIN_DIR="$(mktemp -d)"
+    export PATH="$MOCK_BIN_DIR:$PATH"
+
+    cat << 'MOCK' > "$MOCK_BIN_DIR/ansible-playbook"
+#!/bin/bash
+echo "ansible-playbook $*"
+MOCK
+    chmod +x "$MOCK_BIN_DIR/ansible-playbook"
+
+    export GITHUB_STEP_SUMMARY="$(mktemp)"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN_DIR"
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "run-playbook.sh calls ansible-playbook with correct arguments" {
+    run ./bin/ci/run-playbook.sh
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" == "ansible-playbook -i ansible/playbooks/inventory ansible/playbooks/main.yml" ]]
+    grep -q "Ansible Playbook Run" "$GITHUB_STEP_SUMMARY"
+}


### PR DESCRIPTION
Extracted inline scripts from `.github/workflows/ansible-play-docker-swarm.yml` into standalone bash scripts (`ansible-lint.sh` and `run-playbook.sh`) inside `bin/ci/`. This aligns with the CI requirement to avoid multi-line inline scripts. Added GitHub Step Summary logging and bats test coverage for the new scripts. Verified with conftest.

---
*PR created automatically by Jules for task [15594228747360562526](https://jules.google.com/task/15594228747360562526) started by @xNok*