### PR TITLE
ci: generate summary for flux tests and fix inline script policy

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/tests/flux-d2/test.sh

--- a/bin/tests/flux-d2/test.sh
+++ b/bin/tests/flux-d2/test.sh
@@ -178,6 +178,10 @@ main() {
   verify_openziti_stack
 
   echo -e "\n${GREEN}${BOLD}  ✔  Flux D2 bootstrap test completed successfully!${RESET}\n"
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "### :rocket: Flux D2 bootstrap test completed successfully" >> "$GITHUB_STEP_SUMMARY"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
This PR targets the `flux-test.yml` workflow and its associated script `bin/tests/flux-d2/test.sh` to implement requested CI/CD improvements, focusing on a specific area to keep the scope small.

Key changes:
- Refactored the `flux-test.yml` step to avoid the multiline YAML block (`|`), passing the `conftest` policy for inline scripts.
- Added logic in `test.sh` to append a success status to `$GITHUB_STEP_SUMMARY`, ensuring the workflow produces a descriptive summary.
- Ensured testing logic locally via BATS remained functional and unchanged.

---
*PR created automatically by Jules for task [6977387259579625689](https://jules.google.com/task/6977387259579625689) started by @xNok*