### PR TITLE
ci: remove inline script and add step summary to flux test

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/tests/flux-d2/test.sh

--- a/bin/tests/flux-d2/test.sh
+++ b/bin/tests/flux-d2/test.sh
@@ -178,6 +178,10 @@ main() {
   verify_openziti_stack
 
   echo -e "\n${GREEN}${BOLD}  ✔  Flux D2 bootstrap test completed successfully!${RESET}\n"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "### :rocket: Flux D2 bootstrap test completed successfully!" >> "$GITHUB_STEP_SUMMARY"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
Resolves issues with inline scripts in `.github/workflows/flux-test.yml` by calling the script on a single line, adhering to CI standards. Additionally updates `bin/tests/flux-d2/test.sh` to output execution success to `$GITHUB_STEP_SUMMARY` to align with the expectation that all workflows produce summaries.

---
*PR created automatically by Jules for task [567456034855156598](https://jules.google.com/task/567456034855156598) started by @xNok*