### PR TITLE
refactor: extract flux-test.yml run block to script with summary and tests

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/ci/flux-test.sh

--- a/bin/ci/flux-test.sh
+++ b/bin/ci/flux-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Add a summary header to the GITHUB_STEP_SUMMARY if available
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### Flux D2 Integration Test" >> "$GITHUB_STEP_SUMMARY"
+  echo "Running the flux bootstrap test script..." >> "$GITHUB_STEP_SUMMARY"
+fi
+
+./bin/tests/flux-d2/test.sh

--- a/bin/tests/ci/test_flux-test.bats
+++ b/bin/tests/ci/test_flux-test.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_DIR="$(mktemp -d)"
+
+  # Mock GITHUB_STEP_SUMMARY
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+
+  # Mock bin/tests/flux-d2/test.sh inside the test workspace to avoid running actual integration tests
+  export WORKSPACE_DIR="$MOCK_DIR/workspace"
+  mkdir -p "$WORKSPACE_DIR/bin/tests/flux-d2"
+
+  cat << 'SCRIPT' > "$WORKSPACE_DIR/bin/tests/flux-d2/test.sh"
+#!/usr/bin/env bash
+echo "Mock flux-d2/test.sh executed successfully."
+exit 0
+SCRIPT
+  chmod +x "$WORKSPACE_DIR/bin/tests/flux-d2/test.sh"
+
+  # Copy the script to test into the workspace
+  mkdir -p "$WORKSPACE_DIR/bin/ci"
+  cp "bin/ci/flux-test.sh" "$WORKSPACE_DIR/bin/ci/flux-test.sh"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+  rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "flux-test.sh writes to GITHUB_STEP_SUMMARY if available and executes the underlying script" {
+  cd "$WORKSPACE_DIR"
+
+  run ./bin/ci/flux-test.sh
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Mock flux-d2/test.sh executed successfully."* ]]
+
+  # Check if GITHUB_STEP_SUMMARY was populated
+  summary_content=$(cat "$GITHUB_STEP_SUMMARY")
+  [[ "$summary_content" == *"### Flux D2 Integration Test"* ]]
+  [[ "$summary_content" == *"Running the flux bootstrap test script..."* ]]
+}
+
+@test "flux-test.sh works if GITHUB_STEP_SUMMARY is not set" {
+  cd "$WORKSPACE_DIR"
+
+  unset GITHUB_STEP_SUMMARY
+
+  run ./bin/ci/flux-test.sh
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Mock flux-d2/test.sh executed successfully."* ]]
+}


### PR DESCRIPTION
Resolves inline script policy violation in `flux-test.yml` by extracting the `Run Test Script` step into a dedicated executable script.

Changes included:
* Created `bin/ci/flux-test.sh` to wrap the call to `./bin/tests/flux-d2/test.sh`.
* Added `GITHUB_STEP_SUMMARY` support to the wrapper script.
* Created BATS tests `bin/tests/ci/test_flux-test.bats` and fully tested the wrapper script (using mocks to ensure isolation).
* Updated `.github/workflows/flux-test.yml` to utilize the new script.
* Confirmed conftest `inline_scripts.rego` policy passes on the updated workflow.

---
*PR created automatically by Jules for task [9353159213344019769](https://jules.google.com/task/9353159213344019769) started by @xNok*