### PR TITLE
Extract inline CI scripts in flux-test workflow and add BATS test

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/ci/run-flux-test.sh

--- a/bin/ci/lib/step-summary.sh
+++ b/bin/ci/lib/step-summary.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Writes a message to the GitHub Step Summary if it's available
+write_step_summary() {
+  local message="$1"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "✅ $message" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}

--- a/bin/ci/run-flux-test.sh
+++ b/bin/ci/run-flux-test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/step-summary.sh"
+
+./bin/tests/flux-d2/test.sh
+
+write_step_summary "Flux D2 bootstrap test completed successfully"

--- a/bin/tests/ci/test_run_flux_test.bats
+++ b/bin/tests/ci/test_run_flux_test.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export MOCK_BIN_DIR="$(mktemp -d)"
+  export PATH="$MOCK_BIN_DIR:$PATH"
+
+  # Create a full mock workspace
+  export MOCK_WORKSPACE="$(mktemp -d)"
+  cd "$MOCK_WORKSPACE"
+
+  mkdir -p bin/ci/lib
+  cp "$BATS_TEST_DIRNAME/../../ci/run-flux-test.sh" bin/ci/
+  cp "$BATS_TEST_DIRNAME/../../ci/lib/step-summary.sh" bin/ci/lib/
+
+  mkdir -p bin/tests/flux-d2
+  cat << 'MOCK' > bin/tests/flux-d2/test.sh
+#!/bin/bash
+echo "Mock flux test script called"
+MOCK
+  chmod +x bin/tests/flux-d2/test.sh
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+  rm -rf "$MOCK_BIN_DIR"
+  rm -rf "$MOCK_WORKSPACE"
+}
+
+@test "run-flux-test.sh calls flux test script and writes to summary" {
+  run ./bin/ci/run-flux-test.sh
+  [ "$status" -eq 0 ]
+
+  # Check if output contains mock calls
+  [[ "${lines[0]}" == "Mock flux test script called" ]]
+
+  # Check if summary was written
+  grep "Flux D2 bootstrap test completed successfully" "$GITHUB_STEP_SUMMARY"
+}


### PR DESCRIPTION
Extracted the inline multiline scripts from the flux-test.yml workflow to bin/ci/run-flux-test.sh to comply with inline_scripts.rego policy. Created a reusable bin/ci/lib/step-summary.sh utility to write step summaries and added a BATS test to verify the script.

---
*PR created automatically by Jules for task [12993854151639264018](https://jules.google.com/task/12993854151639264018) started by @xNok*