### PR TITLE
Refactor bats.yml to remove inline bash script

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -26,4 +26,4 @@ jobs:
         run: ./bin/ci/lib/install-bats.sh
 
       - name: Run BATS tests
-        run: bats bin/tests/ci
+        run: ./bin/ci/lib/run-bats-tests.sh

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install BATS
-        run: sudo apt-get update && sudo apt-get install -y bats
+        run: ./bin/ci/lib/install-bats.sh
 
       - name: Run BATS tests
         run: bats bin/tests/ci

--- a/bin/ci/lib/install-bats.sh
+++ b/bin/ci/lib/install-bats.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y bats
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :hammer_and_wrench: Installed BATS" >> "$GITHUB_STEP_SUMMARY"
+  echo "BATS version: $(bats -v)" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/ci/lib/run-bats-tests.sh
+++ b/bin/ci/lib/run-bats-tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bats --formatter tap bin/tests/ci > test_results.tap
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :test_tube: BATS Test Results" >> "$GITHUB_STEP_SUMMARY"
+  echo '```tap' >> "$GITHUB_STEP_SUMMARY"
+  cat test_results.tap >> "$GITHUB_STEP_SUMMARY"
+  echo '```' >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Print it so we can see the results in CI logs
+cat test_results.tap

--- a/bin/ci/lib/run-bats-tests.sh
+++ b/bin/ci/lib/run-bats-tests.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-bats --formatter tap bin/tests/ci > test_results.tap
+# Run bats and capture output while preserving the exit code
+exit_code=0
+bats_output=$(bats --formatter tap bin/tests/ci) || exit_code=$?
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   echo "### :test_tube: BATS Test Results" >> "$GITHUB_STEP_SUMMARY"
   echo '```tap' >> "$GITHUB_STEP_SUMMARY"
-  cat test_results.tap >> "$GITHUB_STEP_SUMMARY"
+  echo "$bats_output" >> "$GITHUB_STEP_SUMMARY"
   echo '```' >> "$GITHUB_STEP_SUMMARY"
 fi
 
 # Print it so we can see the results in CI logs
-cat test_results.tap
+echo "$bats_output"
+
+# Exit with the actual result of the bats command
+exit "$exit_code"

--- a/bin/tests/ci/test_install-bats.bats
+++ b/bin/tests/ci/test_install-bats.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export MOCK_BIN_DIR="$(mktemp -d)"
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+
+  cat << 'MOCK' > "${MOCK_BIN_DIR}/sudo"
+#!/usr/bin/env bash
+if [ "$1" = "apt-get" ]; then
+  if [ "$2" = "update" ]; then
+    echo "Mock apt-get update"
+  elif [ "$2" = "install" ] && [ "$3" = "-y" ] && [ "$4" = "bats" ]; then
+    echo "Mock apt-get install bats"
+  fi
+fi
+MOCK
+  chmod +x "${MOCK_BIN_DIR}/sudo"
+
+  cat << 'MOCK' > "${MOCK_BIN_DIR}/bats"
+#!/usr/bin/env bash
+if [ "$1" = "-v" ]; then
+  echo "Bats 1.9.0"
+fi
+MOCK
+  chmod +x "${MOCK_BIN_DIR}/bats"
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+  rm -rf "$MOCK_BIN_DIR"
+}
+
+@test "install-bats.sh installs bats and writes summary" {
+  run ./bin/ci/lib/install-bats.sh
+
+  [ "$status" -eq 0 ]
+  run grep "### :hammer_and_wrench: Installed BATS" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  run grep "BATS version: Bats 1.9.0" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}

--- a/bin/tests/ci/test_run-bats-tests.bats
+++ b/bin/tests/ci/test_run-bats-tests.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export MOCK_BIN_DIR="$(mktemp -d)"
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+
+  cat << 'MOCK' > "${MOCK_BIN_DIR}/bats"
+#!/usr/bin/env bash
+if [ "$1" = "--formatter" ] && [ "$2" = "tap" ]; then
+  echo "1..1"
+  echo "ok 1 test pass"
+fi
+MOCK
+  chmod +x "${MOCK_BIN_DIR}/bats"
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+  rm -rf "$MOCK_BIN_DIR"
+  rm -f test_results.tap
+}
+
+@test "run-bats-tests.sh runs bats, creates tap output and writes to summary" {
+  run ./bin/ci/lib/run-bats-tests.sh
+
+  [ "$status" -eq 0 ]
+
+  run grep "### :test_tube: BATS Test Results" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+
+  run grep "ok 1 test pass" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+
+  run grep "ok 1 test pass" test_results.tap
+  [ "$status" -eq 0 ]
+}

--- a/bin/tests/ci/test_run-bats-tests.bats
+++ b/bin/tests/ci/test_run-bats-tests.bats
@@ -18,10 +18,9 @@ MOCK
 teardown() {
   rm -f "$GITHUB_STEP_SUMMARY"
   rm -rf "$MOCK_BIN_DIR"
-  rm -f test_results.tap
 }
 
-@test "run-bats-tests.sh runs bats, creates tap output and writes to summary" {
+@test "run-bats-tests.sh runs bats, captures tap output and writes to summary" {
   run ./bin/ci/lib/run-bats-tests.sh
 
   [ "$status" -eq 0 ]
@@ -32,6 +31,6 @@ teardown() {
   run grep "ok 1 test pass" "$GITHUB_STEP_SUMMARY"
   [ "$status" -eq 0 ]
 
-  run grep "ok 1 test pass" test_results.tap
+  run grep "ok 1 test pass" <<< "$output"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Extract the inline `apt-get install` command to its own script `bin/ci/lib/install-bats.sh` and update `bats.yml` to call it. Add missing test file `bin/tests/ci/test_install-bats.bats` as requested by rules.

---
*PR created automatically by Jules for task [4268486782083962579](https://jules.google.com/task/4268486782083962579) started by @xNok*