### PR TITLE
ci: extract flux test script to comply with inline policy

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/ci/run-flux-test.sh

--- a/bin/ci/run-flux-test.sh
+++ b/bin/ci/run-flux-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+FLUX_TEST_SCRIPT="${FLUX_TEST_SCRIPT:-./bin/tests/flux-d2/test.sh}"
+
+echo "Running Flux D2 test script: ${FLUX_TEST_SCRIPT}"
+
+set +e
+"${FLUX_TEST_SCRIPT}" 2>&1 | tee test-results.log
+EXIT_CODE=${PIPESTATUS[0]}
+set -e
+
+if [ -n "$GITHUB_STEP_SUMMARY" ]; then
+  if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "### :white_check_mark: Flux Bootstrap Test Succeeded" >> "$GITHUB_STEP_SUMMARY"
+  else
+    echo "### :x: Flux Bootstrap Test Failed" >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  echo "<details><summary>Test Logs (last 100 lines)</summary>" >> "$GITHUB_STEP_SUMMARY"
+  echo "" >> "$GITHUB_STEP_SUMMARY"
+  echo '```' >> "$GITHUB_STEP_SUMMARY"
+  tail -n 100 test-results.log >> "$GITHUB_STEP_SUMMARY"
+  echo '```' >> "$GITHUB_STEP_SUMMARY"
+  echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+exit "$EXIT_CODE"

--- a/bin/tests/ci/test_run-flux-test.bats
+++ b/bin/tests/ci/test_run-flux-test.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export MOCK_DIR="$(mktemp -d)"
+
+  # Create a mock success script
+  export MOCK_SUCCESS_SCRIPT="${MOCK_DIR}/mock-success.sh"
+  cat << 'EOF' > "$MOCK_SUCCESS_SCRIPT"
+#!/usr/bin/env bash
+echo "Mock successful test"
+exit 0
+EOF
+  chmod +x "$MOCK_SUCCESS_SCRIPT"
+
+  # Create a mock failure script
+  export MOCK_FAILURE_SCRIPT="${MOCK_DIR}/mock-failure.sh"
+  cat << 'EOF' > "$MOCK_FAILURE_SCRIPT"
+#!/usr/bin/env bash
+echo "Mock failing test"
+exit 1
+EOF
+  chmod +x "$MOCK_FAILURE_SCRIPT"
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+  rm -f test-results.log
+  rm -rf "$MOCK_DIR"
+}
+
+@test "run-flux-test.sh captures successful exit code and writes success summary" {
+  export FLUX_TEST_SCRIPT="$MOCK_SUCCESS_SCRIPT"
+  run ./bin/ci/run-flux-test.sh
+
+  [ "$status" -eq 0 ]
+
+  run grep "### :white_check_mark: Flux Bootstrap Test Succeeded" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+
+  run grep "Mock successful test" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}
+
+@test "run-flux-test.sh captures failing exit code and writes failure summary" {
+  export FLUX_TEST_SCRIPT="$MOCK_FAILURE_SCRIPT"
+  run ./bin/ci/run-flux-test.sh
+
+  [ "$status" -eq 1 ]
+
+  run grep "### :x: Flux Bootstrap Test Failed" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+
+  run grep "Mock failing test" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Extracted the multiline inline script from the `flux-test.yml` GitHub workflow into a dedicated, executable wrapper script `bin/ci/run-flux-test.sh`.

- Added `run-flux-test.sh` to handle test execution and append success/failure results along with the last 100 lines of logs to `$GITHUB_STEP_SUMMARY`.
- Added corresponding BATS test suite `bin/tests/ci/test_run-flux-test.bats` using mocked success/failure scripts in a safe temporary directory to verify the wrapper's behavior and exit code handling.
- Updated `flux-test.yml` to call `run: ./bin/ci/run-flux-test.sh`, achieving compliance with the `policies/ci/inline_scripts.rego` CI policy.

---
*PR created automatically by Jules for task [9293444396269997822](https://jules.google.com/task/9293444396269997822) started by @xNok*