### PR TITLE
Refactor flux-test workflow to use dedicated wrapper script

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/ci/run-flux-test.sh

--- a/bin/ci/run-flux-test.sh
+++ b/bin/ci/run-flux-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+LOG_FILE=$(mktemp)
+
+echo "Running Flux D2 integration tests..."
+
+# Temporarily disable set -e to capture the exit code
+set +e
+"${ROOT_DIR}/bin/tests/flux-d2/test.sh" > "$LOG_FILE" 2>&1
+TEST_EXIT_CODE=$?
+set -e
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :test_tube: Flux D2 Test Results" >> "$GITHUB_STEP_SUMMARY"
+
+  if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo "**Status:** :white_check_mark: Passed" >> "$GITHUB_STEP_SUMMARY"
+  else
+    echo "**Status:** :x: Failed" >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  echo "<details><summary>Test Logs</summary>" >> "$GITHUB_STEP_SUMMARY"
+  echo "" >> "$GITHUB_STEP_SUMMARY"
+  echo '```text' >> "$GITHUB_STEP_SUMMARY"
+  cat "$LOG_FILE" >> "$GITHUB_STEP_SUMMARY"
+  echo '```' >> "$GITHUB_STEP_SUMMARY"
+  echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+cat "$LOG_FILE"
+rm -f "$LOG_FILE"
+
+exit $TEST_EXIT_CODE

--- a/bin/tests/ci/test_run-flux-test.bats
+++ b/bin/tests/ci/test_run-flux-test.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_DIR="$(mktemp -d)"
+  export MOCK_BIN_DIR="${MOCK_DIR}/bin"
+  mkdir -p "${MOCK_BIN_DIR}"
+  export PATH="${MOCK_BIN_DIR}:$PATH"
+
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+
+  # Mock bin/tests/flux-d2/test.sh
+  export MOCK_FLUX_TEST_DIR="${MOCK_DIR}/bin/tests/flux-d2"
+  mkdir -p "${MOCK_FLUX_TEST_DIR}"
+  export MOCK_FLUX_TEST_SCRIPT="${MOCK_FLUX_TEST_DIR}/test.sh"
+
+  # Keep a real bin directory structure but inside MOCK_DIR for testing?
+  # No, the script uses ROOT_DIR to call bin/tests/flux-d2/test.sh
+  # Since ROOT_DIR is calculated relative to the script's location, we need to create
+  # a fake ROOT_DIR structure and place our script there to test it properly,
+  # or we can just mock the test script in the real tree temporarily? No, that's dangerous.
+
+  # Let's copy the script to a mock directory structure so it resolves ROOT_DIR to MOCK_DIR
+  export FAKE_ROOT="${MOCK_DIR}/repo"
+  mkdir -p "${FAKE_ROOT}/bin/ci"
+  mkdir -p "${FAKE_ROOT}/bin/tests/flux-d2"
+
+  cp bin/ci/run-flux-test.sh "${FAKE_ROOT}/bin/ci/run-flux-test.sh"
+  chmod +x "${FAKE_ROOT}/bin/ci/run-flux-test.sh"
+
+  export SCRIPT_UNDER_TEST="${FAKE_ROOT}/bin/ci/run-flux-test.sh"
+}
+
+teardown() {
+  rm -rf "${MOCK_DIR}"
+  rm -f "${GITHUB_STEP_SUMMARY}"
+}
+
+@test "run-flux-test.sh succeeds and writes summary on test success" {
+  cat << 'EOF' > "${FAKE_ROOT}/bin/tests/flux-d2/test.sh"
+#!/bin/bash
+echo "Fake tests passed"
+exit 0
+EOF
+  chmod +x "${FAKE_ROOT}/bin/tests/flux-d2/test.sh"
+
+  run "${SCRIPT_UNDER_TEST}"
+
+  [ "$status" -eq 0 ]
+
+  # Check output
+  echo "$output" | grep "Fake tests passed"
+
+  # Check summary
+  grep "### :test_tube: Flux D2 Test Results" "$GITHUB_STEP_SUMMARY"
+  grep "\*\*Status:\*\* :white_check_mark: Passed" "$GITHUB_STEP_SUMMARY"
+  grep "Fake tests passed" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "run-flux-test.sh fails and writes summary on test failure" {
+  cat << 'EOF' > "${FAKE_ROOT}/bin/tests/flux-d2/test.sh"
+#!/bin/bash
+echo "Fake tests failed"
+exit 1
+EOF
+  chmod +x "${FAKE_ROOT}/bin/tests/flux-d2/test.sh"
+
+  run "${SCRIPT_UNDER_TEST}"
+
+  [ "$status" -eq 1 ]
+
+  # Check output
+  echo "$output" | grep "Fake tests failed"
+
+  # Check summary
+  grep "### :test_tube: Flux D2 Test Results" "$GITHUB_STEP_SUMMARY"
+  grep "\*\*Status:\*\* :x: Failed" "$GITHUB_STEP_SUMMARY"
+  grep "Fake tests failed" "$GITHUB_STEP_SUMMARY"
+}


### PR DESCRIPTION
Refactored the `flux-test.yml` workflow by removing inline scripts in favor of a dedicated and tested wrapper script in `bin/ci/run-flux-test.sh`. This ensures compliance with CI/CD policies, improves reusability, and properly generates standard GitHub step summaries for better visibility into pipeline executions. Added corresponding BATS tests to ensure proper behavior.

---
*PR created automatically by Jules for task [10624354603197054474](https://jules.google.com/task/10624354603197054474) started by @xNok*