### PR TITLE
ci: refactor flux-test workflow to use dedicated wrapper script

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/ci/run-flux-test.sh

--- a/bin/ci/run-flux-test.sh
+++ b/bin/ci/run-flux-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR="${ROOT_DIR:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+# Output summary to GitHub Actions if GITHUB_STEP_SUMMARY is set
+GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-""}
+
+LOG_FILE=$(mktemp)
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "Running Flux D2 bootstrap test..."
+set +e
+"${ROOT_DIR}/bin/tests/flux-d2/test.sh" 2>&1 | tee "$LOG_FILE"
+EXIT_CODE=${PIPESTATUS[0]}
+set -e
+
+if [[ -n "$GITHUB_STEP_SUMMARY" ]]; then
+  {
+    echo "## Flux D2 Bootstrap Test Results"
+    echo ""
+    if [[ $EXIT_CODE -eq 0 ]]; then
+      echo "✅ **Status:** Passed"
+    else
+      echo "❌ **Status:** Failed"
+    fi
+    echo ""
+    echo "<details><summary>Test Output</summary>"
+    echo ""
+    echo '```text'
+    cat "$LOG_FILE"
+    echo '```'
+    echo "</details>"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+exit $EXIT_CODE

--- a/bin/tests/ci/test_run-flux-test.bats
+++ b/bin/tests/ci/test_run-flux-test.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export MOCK_DIR="$(mktemp -d)"
+  export MOCK_BIN_DIR="${MOCK_DIR}/bin"
+  export MOCK_TEST_DIR="${MOCK_DIR}/bin/tests/flux-d2"
+
+  mkdir -p "$MOCK_BIN_DIR"
+  mkdir -p "$MOCK_TEST_DIR"
+
+  export SCRIPT_TO_TEST="${BATS_TEST_DIRNAME}/../../ci/run-flux-test.sh"
+  export ROOT_DIR="$MOCK_DIR"
+
+  export TEST_SCRIPT="${MOCK_DIR}/run-flux-test.sh"
+  cp "$SCRIPT_TO_TEST" "$TEST_SCRIPT"
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+  rm -rf "$MOCK_DIR"
+}
+
+@test "run-flux-test.sh succeeds and generates summary on success" {
+  cat << 'EOF' > "${MOCK_TEST_DIR}/test.sh"
+#!/usr/bin/env bash
+echo "Mock Flux Test Script Execution: SUCCESS"
+exit 0
+EOF
+  chmod +x "${MOCK_TEST_DIR}/test.sh"
+
+  run "$TEST_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Mock Flux Test Script Execution: SUCCESS"* ]]
+
+  # Check summary
+  cat "$GITHUB_STEP_SUMMARY"
+  summary_content=$(cat "$GITHUB_STEP_SUMMARY")
+  [[ "$summary_content" == *"## Flux D2 Bootstrap Test Results"* ]]
+  [[ "$summary_content" == *"✅ **Status:** Passed"* ]]
+  [[ "$summary_content" == *"Mock Flux Test Script Execution: SUCCESS"* ]]
+}
+
+@test "run-flux-test.sh fails and generates summary on failure" {
+  cat << 'EOF' > "${MOCK_TEST_DIR}/test.sh"
+#!/usr/bin/env bash
+echo "Mock Flux Test Script Execution: FAILURE"
+exit 1
+EOF
+  chmod +x "${MOCK_TEST_DIR}/test.sh"
+
+  run "$TEST_SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Mock Flux Test Script Execution: FAILURE"* ]]
+
+  # Check summary
+  summary_content=$(cat "$GITHUB_STEP_SUMMARY")
+  [[ "$summary_content" == *"## Flux D2 Bootstrap Test Results"* ]]
+  [[ "$summary_content" == *"❌ **Status:** Failed"* ]]
+  [[ "$summary_content" == *"Mock Flux Test Script Execution: FAILURE"* ]]
+}


### PR DESCRIPTION
This PR resolves the `inline_scripts.rego` policy violation in the `flux-test.yml` workflow by moving the multiline script execution into a dedicated, reusable CI wrapper script.

Changes included:
* Created `bin/ci/run-flux-test.sh` to execute the core test and append results to `$GITHUB_STEP_SUMMARY`.
* Updated `.github/workflows/flux-test.yml` to use a single-line `run: ./bin/ci/run-flux-test.sh`.
* Added BATS tests for the new script in `bin/tests/ci/test_run-flux-test.bats`.

---
*PR created automatically by Jules for task [7292350372514016715](https://jules.google.com/task/7292350372514016715) started by @xNok*