### PR TITLE
ci: extract inline flux test script to dedicated wrapper

### DIFF
--- a/.github/workflows/flux-test.yml
+++ b/.github/workflows/flux-test.yml
@@ -31,5 +31,4 @@ jobs:
           FLEET_NAME: kind
           SOURCE_URL: ${{ github.event.repository.html_url }}
           REVISION: ${{ github.sha }}
-        run: |
-          ./bin/tests/flux-d2/test.sh
+        run: ./bin/ci/run-flux-test.sh

--- a/bin/ci/run-flux-test.sh
+++ b/bin/ci/run-flux-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# run-flux-test.sh
+# Wrapper script to run Flux D2 tests and report the summary to GitHub Actions
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR="${ROOT_DIR:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+LOG_FILE=$(mktemp)
+GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+echo "Running Flux D2 tests..."
+set +e
+"${ROOT_DIR}/bin/tests/flux-d2/test.sh" > "$LOG_FILE" 2>&1
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "### :white_check_mark: Flux D2 tests completed successfully" >> "$GITHUB_STEP_SUMMARY"
+else
+  echo "### :x: Flux D2 tests failed" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "<details><summary>Test Output</summary>" >> "$GITHUB_STEP_SUMMARY"
+echo "" >> "$GITHUB_STEP_SUMMARY"
+echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+cat "$LOG_FILE" >> "$GITHUB_STEP_SUMMARY"
+echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+echo "" >> "$GITHUB_STEP_SUMMARY"
+echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+
+cat "$LOG_FILE"
+rm -f "$LOG_FILE"
+
+exit $EXIT_CODE

--- a/bin/tests/ci/test_run-flux-test.bats
+++ b/bin/tests/ci/test_run-flux-test.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_DIR="$(mktemp -d)"
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export ROOT_DIR="$MOCK_DIR"
+
+  # Create mock target directory
+  mkdir -p "${ROOT_DIR}/bin/tests/flux-d2"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+  rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "run-flux-test.sh completes successfully and writes success to summary" {
+  # Mock the inner script to succeed
+  cat << 'EOF' > "${ROOT_DIR}/bin/tests/flux-d2/test.sh"
+#!/usr/bin/env bash
+echo "Mock success"
+exit 0
+EOF
+  chmod +x "${ROOT_DIR}/bin/tests/flux-d2/test.sh"
+
+  run ./bin/ci/run-flux-test.sh
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Mock success"* ]]
+
+  # Verify summary
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"### :white_check_mark: Flux D2 tests completed successfully"* ]]
+  [[ "$output" == *"Mock success"* ]]
+}
+
+@test "run-flux-test.sh fails and writes error to summary" {
+  # Mock the inner script to fail
+  cat << 'EOF' > "${ROOT_DIR}/bin/tests/flux-d2/test.sh"
+#!/usr/bin/env bash
+echo "Mock failure"
+exit 1
+EOF
+  chmod +x "${ROOT_DIR}/bin/tests/flux-d2/test.sh"
+
+  run ./bin/ci/run-flux-test.sh
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Mock failure"* ]]
+
+  # Verify summary
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"### :x: Flux D2 tests failed"* ]]
+  [[ "$output" == *"Mock failure"* ]]
+}


### PR DESCRIPTION
This PR extracts the multiline inline script from `.github/workflows/flux-test.yml` into a dedicated wrapper script (`bin/ci/run-flux-test.sh`). 

The new wrapper script correctly runs the underlying Flux test script and parses its output into the `$GITHUB_STEP_SUMMARY`, satisfying the CI/CD requirements for Step Summaries.
A comprehensive BATS test suite (`bin/tests/ci/test_run-flux-test.bats`) was also added to explicitly test the wrapper's behavior in both successful and failure paths using mocked executions.
This ensures compliance with the `inline_scripts.rego` policy and improves testability of the workflow actions.

---
*PR created automatically by Jules for task [13861496188996151183](https://jules.google.com/task/13861496188996151183) started by @xNok*