### PR TITLE
Extract inline scripts from release-ansible.yml

### DIFF
--- a/.github/workflows/release-ansible.yml
+++ b/.github/workflows/release-ansible.yml
@@ -56,7 +56,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Ansible dependencies
-        run: pip install ansible-core
+        run: ./bin/ci/lib/install-ansible-core.sh
 
       - name: Install mikefarah/yq
         run: ./bin/ci/lib/install-yq.sh
@@ -70,7 +70,7 @@ jobs:
         run: ./bin/ci/lib/extract-version.sh
 
       - name: Update collection version
-        run: yq -i ".version = \"${{ steps.get_version.outputs.VERSION }}\"" ${{ inputs.collection_dir || 'ansible' }}/galaxy.yml
+        run: ./bin/ci/lib/update-collection-version.sh "${{ steps.get_version.outputs.VERSION }}" "${{ inputs.collection_dir || 'ansible' }}"
 
       - name: Build Ansible Collection
         id: build

--- a/bin/ci/lib/install-ansible-core.sh
+++ b/bin/ci/lib/install-ansible-core.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pip install ansible-core
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :hammer_and_wrench: Installed Ansible Core" >> "$GITHUB_STEP_SUMMARY"
+  if command -v ansible >/dev/null 2>&1; then
+    echo "Ansible version: $(ansible --version | head -n 1)" >> "$GITHUB_STEP_SUMMARY"
+  fi
+fi

--- a/bin/ci/lib/update-collection-version.sh
+++ b/bin/ci/lib/update-collection-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <collection_dir>"
+  exit 1
+fi
+
+VERSION="$1"
+COLLECTION_DIR="$2"
+
+yq -i ".version = \"${VERSION}\"" "${COLLECTION_DIR}/galaxy.yml"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :label: Updated Collection Version" >> "$GITHUB_STEP_SUMMARY"
+  echo "Set version to \`${VERSION}\` in \`${COLLECTION_DIR}/galaxy.yml\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_install-ansible-core.bats
+++ b/bin/tests/ci/test_install-ansible-core.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+    export MOCK_BIN_DIR="$(mktemp -d)"
+    export PATH="$MOCK_BIN_DIR:$PATH"
+
+    cat << 'MOCK' > "$MOCK_BIN_DIR/pip"
+#!/bin/bash
+echo "pip $*"
+MOCK
+    chmod +x "$MOCK_BIN_DIR/pip"
+
+    cat << 'MOCK' > "$MOCK_BIN_DIR/ansible"
+#!/bin/bash
+echo "ansible [core 2.14.3]"
+MOCK
+    chmod +x "$MOCK_BIN_DIR/ansible"
+
+    export GITHUB_STEP_SUMMARY="$(mktemp)"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN_DIR"
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "install-ansible-core.sh installs ansible-core and writes to step summary" {
+    run ./bin/ci/lib/install-ansible-core.sh
+    [ "$status" -eq 0 ]
+
+    # Check if pip install was called correctly
+    [[ "${lines[0]}" == "pip install ansible-core" ]]
+
+    # Check if the step summary was updated
+    grep -q "Installed Ansible Core" "$GITHUB_STEP_SUMMARY"
+    grep -q "Ansible version: ansible \[core 2.14.3\]" "$GITHUB_STEP_SUMMARY"
+}

--- a/bin/tests/ci/test_update-collection-version.bats
+++ b/bin/tests/ci/test_update-collection-version.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+    export MOCK_BIN_DIR="$(mktemp -d)"
+    export PATH="$MOCK_BIN_DIR:$PATH"
+
+    cat << 'MOCK' > "$MOCK_BIN_DIR/yq"
+#!/bin/bash
+echo "yq $*"
+MOCK
+    chmod +x "$MOCK_BIN_DIR/yq"
+
+    export GITHUB_STEP_SUMMARY="$(mktemp)"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN_DIR"
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "update-collection-version.sh executes yq with correct arguments and updates step summary" {
+    run ./bin/ci/lib/update-collection-version.sh "1.2.3" "ansible"
+    [ "$status" -eq 0 ]
+
+    # Check if yq was called correctly
+    [[ "${lines[0]}" == "yq -i .version = \"1.2.3\" ansible/galaxy.yml" ]]
+
+    # Check if step summary was updated
+    grep -q "Updated Collection Version" "$GITHUB_STEP_SUMMARY"
+    grep -q "Set version to \`1.2.3\` in \`ansible/galaxy.yml\`" "$GITHUB_STEP_SUMMARY"
+}


### PR DESCRIPTION
Extracts inline scripts from `.github/workflows/release-ansible.yml` into reusable, tested bash files.
- `pip install ansible-core` extracted into `bin/ci/lib/install-ansible-core.sh`
- `yq` command to update version extracted into `bin/ci/lib/update-collection-version.sh`
- Tests added in `bin/tests/ci/test_install-ansible-core.bats` and `bin/tests/ci/test_update-collection-version.bats`

---
*PR created automatically by Jules for task [5666517667593962806](https://jules.google.com/task/5666517667593962806) started by @xNok*