### PR TITLE
chore: extract reusable docker build workflow and centralize triggers

### DIFF
--- a/.github/workflows/docker-caddy-publish.yml
+++ b/.github/workflows/docker-caddy-publish.yml
@@ -1,15 +1,8 @@
 name: Docker Caddy
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
     branches: [ "main" ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
     paths:
       - 'ansible/roles/docker_swarm_app_caddy/assets/**'
       - '.github/workflows/docker-caddy-publish.yml'
@@ -23,87 +16,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}-caddy
-  CONTEXT: ./ansible/roles/docker_swarm_app_caddy/assets
-
-
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/release-docker.yml
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.8.1
-        with:
-          cosign-release: 'v2.2.2'
-
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        with:
-          context: ${{ env.CONTEXT }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: ./bin/ci/sign-docker-image.sh "${TAGS}" "${DIGEST}"
+    with:
+      image_name: ${{ github.repository }}-caddy
+      context: ./ansible/roles/docker_swarm_app_caddy/assets
+      push_image: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-openziti-bootstrap-publish.yml
+++ b/.github/workflows/docker-openziti-bootstrap-publish.yml
@@ -1,15 +1,8 @@
 name: Docker OpenZiti Bootstrap
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
     branches: [ "main" ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
     paths:
       - 'stacks/openziti/bootstrap/**'
       - '.github/workflows/docker-openziti-bootstrap-publish.yml'
@@ -23,87 +16,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}-openziti-bootstrap
-  CONTEXT: ./stacks/openziti/bootstrap
-
-
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/release-docker.yml
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.8.1
-        with:
-          cosign-release: 'v2.2.2'
-
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        with:
-          context: ${{ env.CONTEXT }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: ./bin/ci/sign-docker-image.sh "${TAGS}" "${DIGEST}"
+    with:
+      image_name: ${{ github.repository }}-openziti-bootstrap
+      context: ./stacks/openziti/bootstrap
+      push_image: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,79 @@
+name: Release Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: 'The name of the Docker image (e.g., github.repository-caddy)'
+        required: true
+        type: string
+      context:
+        description: 'The build context for the Docker image'
+        required: true
+        type: string
+      push_image:
+        description: 'Whether to push the built image to the registry'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        if: ${{ inputs.push_image }}
+        uses: sigstore/cosign-installer@v3.8.1
+        with:
+          cosign-release: 'v2.2.2'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: ${{ inputs.push_image }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: ${{ inputs.context }}
+          push: ${{ inputs.push_image }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: ${{ inputs.push_image }}
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: ./bin/ci/sign-docker-image.sh "${TAGS}" "${DIGEST}"
+
+      - name: Create Step Summary
+        run: ./bin/ci/docker-summary.sh "${{ env.REGISTRY }}/${{ inputs.image_name }}" "${{ inputs.push_image }}" "${{ steps.meta.outputs.tags }}" "${{ steps.build-and-push.outputs.digest }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,27 @@ jobs:
       release_tag: ${{ github.ref_name }}
       package_dir: 'kubernetes'
       package_name: 'kubernetes-infra-addons'
+
+  publish-caddy:
+    if: startsWith(github.ref_name, 'caddy@')
+    uses: ./.github/workflows/release-docker.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      image_name: ${{ github.repository }}-caddy
+      context: ./ansible/roles/docker_swarm_app_caddy/assets
+      push_image: true
+
+  publish-openziti-bootstrap:
+    if: startsWith(github.ref_name, 'openziti-bootstrap@')
+    uses: ./.github/workflows/release-docker.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      image_name: ${{ github.repository }}-openziti-bootstrap
+      context: ./stacks/openziti/bootstrap
+      push_image: true

--- a/bin/ci/docker-summary.sh
+++ b/bin/ci/docker-summary.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :rocket: Docker Image Build" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Image:** \`$1\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Pushed:** \`$2\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Tags:** \`$3\`" >> "$GITHUB_STEP_SUMMARY"
+  echo "**Digest:** \`$4\`" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_docker-summary.bats
+++ b/bin/tests/ci/test_docker-summary.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Mock GITHUB_STEP_SUMMARY
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "docker-summary writes to GITHUB_STEP_SUMMARY" {
+  run ./bin/ci/docker-summary.sh "ghcr.io/my-image" "true" "v1.0.0" "sha256:12345"
+
+  [ "$status" -eq 0 ]
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"### :rocket: Docker Image Build"* ]]
+  [[ "$output" == *"**Image:** \`ghcr.io/my-image\`"* ]]
+  [[ "$output" == *"**Pushed:** \`true\`"* ]]
+  [[ "$output" == *"**Tags:** \`v1.0.0\`"* ]]
+  [[ "$output" == *"**Digest:** \`sha256:12345\`"* ]]
+}


### PR DESCRIPTION
This PR reduces CI sprawl and extracts reusable logic by creating a `.github/workflows/release-docker.yml` workflow. It updates `docker-caddy-publish.yml` and `docker-openziti-bootstrap-publish.yml` to call this new workflow, and centralizes tag-based triggering to the main `release.yml`. It also replaces an inline script with `bin/ci/docker-summary.sh` and tests it with bats.

---
*PR created automatically by Jules for task [11055035314449575861](https://jules.google.com/task/11055035314449575861) started by @xNok*