### PR TITLE
ci: extract pip install ansible-core into reusable script

### DIFF
--- a/.github/workflows/release-ansible.yml
+++ b/.github/workflows/release-ansible.yml
@@ -56,7 +56,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Ansible dependencies
-        run: pip install ansible-core
+        run: ./bin/ci/lib/install-ansible-core.sh
 
       - name: Install mikefarah/yq
         run: ./bin/ci/lib/install-yq.sh

--- a/bin/ci/lib/install-ansible-core.sh
+++ b/bin/ci/lib/install-ansible-core.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install ansible-core
+pip install ansible-core
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :hammer_and_wrench: Installed ansible-core" >> "$GITHUB_STEP_SUMMARY"
+  # ansible-galaxy --version or pip show ansible-core could be used for version,
+  # but ansible --version is probably safest to extract the core version.
+  # Assuming ansible or ansible-core is accessible in PATH if pip installs it.
+  echo "ansible-core version: $(pip show ansible-core | grep Version | awk '{print $2}')" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_install-ansible-core.bats
+++ b/bin/tests/ci/test_install-ansible-core.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+setup() {
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  export MOCK_BIN_DIR="$(mktemp -d)"
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+
+  # Mock pip
+  cat << 'EOF' > "${MOCK_BIN_DIR}/pip"
+#!/usr/bin/env bash
+if [ "$1" = "install" ] && [ "$2" = "ansible-core" ]; then
+  echo "Successfully installed ansible-core"
+elif [ "$1" = "show" ] && [ "$2" = "ansible-core" ]; then
+  echo "Name: ansible-core"
+  echo "Version: 2.15.3"
+  echo "Summary: Radically simple IT automation"
+else
+  echo "mock pip $@"
+fi
+EOF
+  chmod +x "${MOCK_BIN_DIR}/pip"
+}
+
+teardown() {
+  rm -f "$GITHUB_STEP_SUMMARY"
+  rm -rf "$MOCK_BIN_DIR"
+}
+
+@test "install-ansible-core.sh installs and reports version" {
+  run ./bin/ci/lib/install-ansible-core.sh
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "Successfully installed ansible-core" ]
+
+  run grep "### :hammer_and_wrench: Installed ansible-core" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+
+  run grep "ansible-core version: 2.15.3" "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Extracts the inline `pip install ansible-core` script from `.github/workflows/release-ansible.yml` into a reusable shell script (`bin/ci/lib/install-ansible-core.sh`) and adds a BATS test (`bin/tests/ci/test_install-ansible-core.bats`) to verify its behavior. The script also includes a GitHub Step Summary output.

---
*PR created automatically by Jules for task [13399385057724326405](https://jules.google.com/task/13399385057724326405) started by @xNok*