### PR TITLE
docs: Prevent mermaid diagram from rendering in home manager article

### DIFF
--- a/website/content/en/blog/home-manager-article/index.md
+++ b/website/content/en/blog/home-manager-article/index.md
@@ -171,7 +171,7 @@ By doing this, AppArmor permits Electron apps running from `/nix/store/` to inst
 
 Integrating 1Password to sign Git commits and manage SSH keys is a massive quality-of-life improvement. However, 1Password consists of two components that must communicate: the **CLI** (`op`) and the **GUI** desktop application.
 
-```mermaid
+```text
 graph TD
     CLI["1Password CLI (op)"] -->|Requests Auth| Socket["~/.1password/agent.sock"]
     Git["Git Commit Signing"] -->|Calls op-ssh-sign| Socket


### PR DESCRIPTION
This PR fixes an issue where a Mermaid diagram in the "home-manager-article" blog post was incorrectly rendering as an actual graphical diagram instead of remaining as a raw code block as requested by the user.

The language identifier for the code block in `website/content/en/blog/home-manager-article/index.md` (around line 174) was changed from `mermaid` to `text`. This ensures the content is treated as a standard text block by the markdown renderer.

---
*PR created automatically by Jules for task [17100333219228053403](https://jules.google.com/task/17100333219228053403) started by @xNok*