### PR TITLE
Extract inline yarn script in release-changeset workflow

### DIFF
--- a/.github/workflows/release-changeset.yml
+++ b/.github/workflows/release-changeset.yml
@@ -24,7 +24,8 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
-      - run: yarn
+      - name: Install dependencies
+        run: ./bin/ci/install-node-deps.sh
 
       - name: Create Release Pull Request or Publish
         id: changesets

--- a/bin/ci/install-node-deps.sh
+++ b/bin/ci/install-node-deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running yarn to install Node.js dependencies..."
+yarn
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### :package: Node.js Dependencies Installed" >> "$GITHUB_STEP_SUMMARY"
+  echo "Dependencies were successfully installed using \`yarn\`." >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/bin/tests/ci/test_install-node-deps.bats
+++ b/bin/tests/ci/test_install-node-deps.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_BIN_DIR="$(mktemp -d)"
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+
+  # Create a mock for yarn
+  cat << 'EOF' > "${MOCK_BIN_DIR}/yarn"
+#!/usr/bin/env bash
+echo "mock yarn executed"
+EOF
+  chmod +x "${MOCK_BIN_DIR}/yarn"
+}
+
+teardown() {
+  rm -rf "${MOCK_BIN_DIR}"
+  rm -f "${GITHUB_STEP_SUMMARY}"
+}
+
+@test "install-node-deps.sh runs yarn and outputs to GITHUB_STEP_SUMMARY" {
+  run ./bin/ci/install-node-deps.sh
+
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "Running yarn to install Node.js dependencies..." ]]
+  [[ "${lines[1]}" == "mock yarn executed" ]]
+
+  # Check GITHUB_STEP_SUMMARY content
+  run cat "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "### :package: Node.js Dependencies Installed" ]]
+  [[ "${lines[1]}" == "Dependencies were successfully installed using \`yarn\`." ]]
+}
+
+@test "install-node-deps.sh fails if yarn fails" {
+  # Modify mock yarn to fail
+  cat << 'EOF' > "${MOCK_BIN_DIR}/yarn"
+#!/usr/bin/env bash
+echo "mock yarn failing"
+exit 1
+EOF
+
+  run ./bin/ci/install-node-deps.sh
+
+  [ "$status" -eq 1 ]
+  [[ "${lines[0]}" == "Running yarn to install Node.js dependencies..." ]]
+  [[ "${lines[1]}" == "mock yarn failing" ]]
+}


### PR DESCRIPTION
Extracts the inline `yarn` command from `.github/workflows/release-changeset.yml` into a dedicated executable script `bin/ci/install-node-deps.sh`. This script now outputs a step summary to comply with CI conventions. Added BATS tests for the new script to ensure it is covered and verified.

---
*PR created automatically by Jules for task [16913111519357768916](https://jules.google.com/task/16913111519357768916) started by @xNok*