### PR TITLE
Setup automated conftest validation for CI workflows

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -1,0 +1,19 @@
+name: Conftest Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  conftest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate with Conftest
+        run: ./bin/ci/run-conftest.sh

--- a/bin/ci/run-conftest.sh
+++ b/bin/ci/run-conftest.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Description: Wrapper script to install and execute conftest against GitHub Actions workflows.
+
+set -euo pipefail
+
+CONFTEST_VERSION="v0.69.0"
+CONFTEST_OS="Linux"
+CONFTEST_ARCH="x86_64"
+CONFTEST_TAR="conftest_${CONFTEST_VERSION#v}_${CONFTEST_OS}_${CONFTEST_ARCH}.tar.gz"
+CONFTEST_URL="https://github.com/open-policy-agent/conftest/releases/download/${CONFTEST_VERSION}/${CONFTEST_TAR}"
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
+POLICIES_DIR="${ROOT_DIR}/policies/ci"
+
+# Download and extract conftest in a temporary directory
+TEMP_DIR=$(mktemp -d)
+OUTPUT_FILE=$(mktemp)
+
+trap 'rm -rf "${TEMP_DIR}" "${OUTPUT_FILE}"' EXIT
+
+echo "Downloading conftest ${CONFTEST_VERSION}..."
+wget -q "${CONFTEST_URL}" -O "${TEMP_DIR}/${CONFTEST_TAR}"
+tar -xzf "${TEMP_DIR}/${CONFTEST_TAR}" -C "${TEMP_DIR}"
+
+CONFTEST_BIN="${TEMP_DIR}/conftest"
+
+echo "Running conftest..."
+set +e
+"${CONFTEST_BIN}" test "${WORKFLOWS_DIR}"/*.yml -p "${POLICIES_DIR}" --all-namespaces --output tap > "${OUTPUT_FILE}" 2>&1
+EXIT_CODE=$?
+set -e
+
+# Output the results to the console
+cat "${OUTPUT_FILE}"
+
+# If running in GitHub Actions, append the results to the step summary
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "### Conftest Results" >> "$GITHUB_STEP_SUMMARY"
+  echo "<details><summary>Click to expand</summary>" >> "$GITHUB_STEP_SUMMARY"
+  echo "" >> "$GITHUB_STEP_SUMMARY"
+  echo '```tap' >> "$GITHUB_STEP_SUMMARY"
+  cat "${OUTPUT_FILE}" >> "$GITHUB_STEP_SUMMARY"
+  echo '```' >> "$GITHUB_STEP_SUMMARY"
+  echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+exit ${EXIT_CODE}

--- a/bin/tests/ci/test_run_conftest.bats
+++ b/bin/tests/ci/test_run_conftest.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+setup() {
+  export MOCK_BIN_DIR="$(mktemp -d)"
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+
+  export TEMP_TEST_DIR="$(mktemp -d)"
+  export ROOT_DIR="${TEMP_TEST_DIR}"
+  export WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
+  export POLICIES_DIR="${ROOT_DIR}/policies/ci"
+
+  mkdir -p "${WORKFLOWS_DIR}"
+  mkdir -p "${POLICIES_DIR}"
+
+  touch "${WORKFLOWS_DIR}/test.yml"
+
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+
+  # Mock wget
+  cat << 'SCRIPT' > "${MOCK_BIN_DIR}/wget"
+#!/bin/bash
+echo "Mock wget called with: $@"
+SCRIPT
+  chmod +x "${MOCK_BIN_DIR}/wget"
+
+  # Mock tar
+  cat << 'SCRIPT' > "${MOCK_BIN_DIR}/tar"
+#!/bin/bash
+echo "Mock tar called with: $@"
+# create mock conftest binary
+for arg in "$@"; do
+    if [[ "$arg" == "-C" ]]; then
+        # The next arg is the directory
+        shift
+        dir="$1"
+        touch "${dir}/conftest"
+        chmod +x "${dir}/conftest"
+
+        # mock conftest to be a bash script that just returns success
+        cat << 'CONFTEST' > "${dir}/conftest"
+#!/bin/bash
+echo "1..1"
+echo "ok 1 - test.yml"
+exit 0
+CONFTEST
+        break
+    fi
+    shift
+done
+SCRIPT
+  chmod +x "${MOCK_BIN_DIR}/tar"
+}
+
+teardown() {
+  rm -rf "${MOCK_BIN_DIR}"
+  rm -rf "${TEMP_TEST_DIR}"
+  rm -f "${GITHUB_STEP_SUMMARY}"
+}
+
+@test "run-conftest.sh executes successfully and outputs to step summary" {
+  run bin/ci/run-conftest.sh
+
+  [ "$status" -eq 0 ]
+
+  # Check if step summary was updated
+  run grep "### Conftest Results" "${GITHUB_STEP_SUMMARY}"
+  [ "$status" -eq 0 ]
+
+  run grep "ok 1 - test.yml" "${GITHUB_STEP_SUMMARY}"
+  [ "$status" -eq 0 ]
+}

--- a/docs/policies/ci.md
+++ b/docs/policies/ci.md
@@ -1,0 +1,3 @@
+# main - No Multiline Inline Scripts
+
+Denies GitHub Actions steps that contain a newline in their `run` command, ensuring scripts are extracted to dedicated files in the `bin/ci` directory.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,35 @@
+# Policies
+
+This directory contains Open Policy Agent (OPA) Rego policies used to validate code and configuration across the repository.
+
+We use `conftest` to run these policies against our configuration files, such as GitHub Actions workflows.
+
+## Validating Policies Locally
+
+To run the policies locally against GitHub Actions workflows, you can use the provided wrapper script:
+
+```bash
+./bin/ci/run-conftest.sh
+```
+
+This script will automatically download the correct version of `conftest` and execute it against the workflows in `.github/workflows/`.
+
+Alternatively, if you have `conftest` installed on your system (e.g., via `brew install conftest`), you can run it directly:
+
+```bash
+conftest test .github/workflows/*.yml -p policies/ci/
+```
+
+## Validating Policies in CI
+
+The `.github/workflows/conftest.yml` workflow automatically runs the policies against all Pull Requests and merges to the `main` branch. This ensures that any changes to our GitHub Actions workflows comply with our defined conventions.
+
+## Auto-generated Documentation
+
+Documentation for the policies is auto-generated using `conftest doc`. The generated documentation can be found in the `docs/policies/` directory.
+
+To regenerate the documentation locally, run:
+
+```bash
+conftest doc policies/ci/ -o docs/policies
+```

--- a/policies/ci/inline_scripts.rego
+++ b/policies/ci/inline_scripts.rego
@@ -1,7 +1,12 @@
+# METADATA
+# title: No Multiline Inline Scripts
+# description: Denies GitHub Actions steps that contain a newline in their `run` command, ensuring scripts are extracted to dedicated files in the `bin/ci` directory.
 package main
 
+import rego.v1
+
 # Deny any run step that contains a newline, suggesting it is a multiline inline script
-deny[msg] {
+deny contains msg if {
   # Match all jobs in the workflow
   some job_id
   job := input.jobs[job_id]

--- a/policies/ci/no_inline_scripts.rego
+++ b/policies/ci/no_inline_scripts.rego
@@ -1,7 +1,0 @@
-package main
-
-deny[msg] {
-  step := input.jobs[_].steps[_]
-  contains(step.run, "\n")
-  msg = sprintf("Inline multi-line scripts are not allowed. Move the script to bin/ci and run it as a single line. Found in step: %v", [step.name])
-}


### PR DESCRIPTION
- Refactored `policies/ci/inline_scripts.rego` to use Rego v1 syntax (`import rego.v1`), added metadata annotations (`# METADATA`), and removed the duplicate `policies/ci/no_inline_scripts.rego`.
- Generated `docs/policies/ci.md` using `conftest doc`.
- Created `policies/README.md` to document the local and CI usage of `conftest`.
- Created an executable wrapper script `bin/ci/run-conftest.sh` that downloads `conftest` securely in a temporary directory, runs it against `.github/workflows/*.yml`, and outputs results to both the console and `$GITHUB_STEP_SUMMARY`.
- Wrote robust BATS tests in `bin/tests/ci/test_run_conftest.bats` that mock `wget` and `tar` to simulate testing execution successfully.
- Added `.github/workflows/conftest.yml` to automatically run `conftest` validations on PRs and merges to `main`.

---
*PR created automatically by Jules for task [1126097521704435534](https://jules.google.com/task/1126097521704435534) started by @xNok*